### PR TITLE
fix: use claude_args for permissions instead of settings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,13 +40,8 @@ jobs:
           # Allow all bots to trigger the review
           allowed_bots: '*'
 
-          # Enable necessary tools for PR review
-          settings: |
-            {
-              "permissions": {
-                "allowAll": true
-              }
-            }
+          # Claude args to allow all tools
+          claude_args: '--permissions allowAll'
 
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.


### PR DESCRIPTION
## Problem

The previous fix using `settings` parameter with `allowAll: true` still resulted in tool permission denials when tested.

## Solution

Switch to using `claude_args: '--permissions allowAll'` which is the correct way to pass permissions to Claude Code CLI.

## Changes

- Replace `settings` block with `claude_args` parameter
- Simplify configuration while achieving the same goal

## Testing

This PR will trigger the Claude Code Review workflow to verify:
- ✅ Claude can use tools (gh CLI, MCP GitHub tools)
- ✅ Claude can create and submit formal PR reviews
- ✅ No permission denials in action logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)