### PR TITLE
fix: use direct_prompt instead of invalid claude_args

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,10 +40,11 @@ jobs:
           # Allow all bots to trigger the review
           allowed_bots: '*'
 
-          # Claude args to allow all tools
-          claude_args: '--permissions allowAll'
+          # Use sticky comments for consistent review updates
+          use_sticky_comment: true
 
-          prompt: |
+          # Direct prompt for automated review (no @claude mention needed)
+          direct_prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             CRITICAL: You MUST post your review using GitHub's review API. Follow these steps:


### PR DESCRIPTION
## Problem

The `claude_args: '--permissions allowAll'` parameter causes the workflow to fail with:
```
error: unknown option '--permissions'
```

The `--permissions` flag doesn't exist in Claude Code CLI.

## Root Cause

We were using:
- Wrong parameter: `prompt` instead of `direct_prompt`
- Invalid CLI flag: `--permissions allowAll` doesn't exist

## Solution

Switch to the correct configuration based on working example from platform-backend:
- Use `direct_prompt` parameter (correct for automated reviews)
- Remove invalid `claude_args` parameter
- Add `use_sticky_comment: true` for better UX

## Changes

```diff
- claude_args: '--permissions allowAll'
- prompt: |
+ use_sticky_comment: true
+ direct_prompt: |
```

## Testing

This PR will trigger the workflow to verify it runs without errors.

## References

- Working example: `hi-env/services/platform-backend/.github/workflows/claude-code-review.yml`
- Error log: Run #18279013045

🤖 Generated with [Claude Code](https://claude.com/claude-code)