### PR TITLE
feat: add Traefik ingress controller deployment

### DIFF
--- a/apps/infrastructure/traefik.yaml
+++ b/apps/infrastructure/traefik.yaml
@@ -1,0 +1,61 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://traefik.github.io/charts
+    chart: traefik
+    targetRevision: 37.1.2
+    helm:
+      valuesObject:
+        # IngressClass configuration
+        ingressClass:
+          enabled: true
+          isDefaultClass: true
+
+        # Service type
+        service:
+          type: LoadBalancer
+
+        # Resource limits
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+
+        # Prometheus metrics
+        metrics:
+          prometheus:
+            service:
+              enabled: true
+            serviceMonitor:
+              enabled: false  # Enable when Prometheus Operator is deployed
+
+        # Dashboard (insecure, only enable temporarily for debugging)
+        ingressRoute:
+          dashboard:
+            enabled: false  # Enable only when needed, exposes metrics/config
+
+        # Logs
+        logs:
+          general:
+            level: INFO
+          access:
+            enabled: true
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
## Summary

Add ArgoCD Application to deploy Traefik ingress controller via official Helm chart.

## Configuration

**Helm Chart:**
- Repository: `https://traefik.github.io/charts`
- Chart: `traefik`
- Version: `37.1.2` (latest stable, signed with provenance)

**Settings:**
- ✅ IngressClass enabled as default
- ✅ LoadBalancer service type
- ✅ Prometheus metrics enabled (ServiceMonitor disabled until Prometheus deployed)
- ✅ Resource limits: 100m-500m CPU, 50Mi-256Mi RAM
- ✅ Auto-sync enabled
- ✅ Dashboard disabled (enable temporarily for debugging only)

## What Happens After Merge

1. ArgoCD detects `apps/infrastructure/traefik.yaml`
2. Pulls Helm chart from Traefik official repository
3. Deploys to `traefik` namespace (auto-created)
4. LoadBalancer service provisions external IP

## Verification

After merge, check deployment:
```bash
kubectl get pods -n traefik
kubectl get svc -n traefik
kubectl get ingressclass
```

## Next Steps

1. Merge this PR
2. Next PR: Deploy cert-manager
3. Next PR: Create Ingress for ArgoCD UI (with TLS via Let's Encrypt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)