### PR TITLE
feat: add Sealed Secrets controller deployment

### DIFF
--- a/apps/infrastructure/sealed-secrets.yaml
+++ b/apps/infrastructure/sealed-secrets.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sealed-secrets
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    chart: sealed-secrets
+    targetRevision: 2.16.2
+    helm:
+      valuesObject:
+        # Use existing secret (BYOK - Bring Your Own Keys)
+        secretName: sealed-secrets-key
+
+        # Controller name (match kubeseal CLI defaults)
+        fullnameOverride: sealed-secrets-controller
+
+        # Resource limits
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sealed-secrets
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
## Summary

Add ArgoCD Application to deploy Sealed Secrets controller via official Helm chart.

## Configuration

**Helm Chart:**
- Repository: `https://bitnami-labs.github.io/sealed-secrets`
- Chart: `sealed-secrets`
- Version: `2.16.2`

**Settings:**
- ✅ BYOK approach: uses existing `sealed-secrets-key` secret (ADR 0009)
- ✅ Controller name: `sealed-secrets-controller` (matches kubeseal CLI defaults)
- ✅ Namespace: `sealed-secrets`
- ✅ Resource limits: 10m-100m CPU, 32Mi-128Mi RAM
- ✅ Auto-sync enabled

## Prerequisites (Manual Bootstrap)

**IMPORTANT:** Before this deploys successfully, you must inject the Sealed Secrets private key:

```bash
# 1. Generate key (if not done already)
openssl req -x509 -nodes -newkey rsa:4096 \
  -keyout sealed-secrets.key -out sealed-secrets.crt \
  -subj "/CN=sealed-secret/O=sealed-secret"

# 2. Inject into cluster
kubectl create namespace sealed-secrets
kubectl -n sealed-secrets create secret tls sealed-secrets-key \
  --cert=sealed-secrets.crt --key=sealed-secrets.key
kubectl -n sealed-secrets label secret sealed-secrets-key \
  sealedsecrets.bitnami.com/sealed-secrets-key=active

# 3. Backup key securely
pass insert -m gitops/sealed-secrets-key < sealed-secrets.key
pass insert -m gitops/sealed-secrets-cert < sealed-secrets.crt
```

See ADR 0009 for details.

## What Happens After Merge

1. ArgoCD detects `apps/infrastructure/sealed-secrets.yaml`
2. Pulls Sealed Secrets Helm chart
3. Deploys controller to `sealed-secrets` namespace
4. Controller uses existing `sealed-secrets-key` secret

## Verification

After merge, check deployment:
```bash
kubectl get pods -n sealed-secrets
kubectl get secret -n sealed-secrets sealed-secrets-key
```

## Next Steps

1. Merge this PR
2. Next PR: Deploy cert-manager + Let's Encrypt ClusterIssuer
3. Next PR: Create ArgoCD Ingress with TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)