### PR TITLE
feat: add cert-manager with Let's Encrypt DNS-01

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ See @adr/README.md for ADR format guidelines.
 - Resources: 12 CPU / 128GB RAM / 280GB SSD
 - Nodes: 1 (single node) → scaling to multi-node
 - Target availability: 99%
+- Domain: `*.ops.last-try.org` (internal infrastructure services)
 
 See individual ADRs for infrastructure and workload details.
 

--- a/apps/infrastructure/cert-manager.yaml
+++ b/apps/infrastructure/cert-manager.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.16.2
+    helm:
+      valuesObject:
+        # Install CRDs
+        crds:
+          enabled: true
+
+        # Resource limits
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+        # Webhook resources
+        webhook:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+
+        # CA injector resources
+        cainjector:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/apps/infrastructure/letsencrypt-issuer.yaml
+++ b/apps/infrastructure/letsencrypt-issuer.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: letsencrypt-issuer
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hitchai-app/gitops
+    path: infrastructure/cert-manager
+    targetRevision: master
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/infrastructure/cert-manager/cloudflare-token-sealed.yaml
+++ b/infrastructure/cert-manager/cloudflare-token-sealed.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: cloudflare-api-token
+  namespace: cert-manager
+spec:
+  encryptedData:
+    api-token: AgCSQ3ai9Y2h7p7x2gv/TXTQ27gaTOmzQoKFbqRKA5xFgizkwaimAOblMK8lQ1R9aRKfRSQgfQ6hvxmwnQ3tw5ScA3baTtCi9iwtq4uDW53985/AnNTjvRYqj4y8PXLi92aJZDy/XPxLFJ+yhl3keBFhrotmxJ7OiWT6Myc62WQJ3JuE12kc+LjS/qfUIbocEvpMujo4PD4o+dNRFglr0SUrBf4Ykqq2o7G3Mz+he1HLUyDXhbgeZ2pigx3KIeMHsmBIWHJslmosReXx2FE9ejJJ/eVqqr6UlBF44H+KuuOY/m9y1KHgBpsMxWK8sr0fJ8D8YMgSvymFDas9ZLbzJZ1M6AAZY6sMtgFGadP2ijQVI1qiteHAjkGyyyliLpLsGjJRlVjCEVN7RrgOEF5VPdEKGE3mEXV0oemIaholA8UyaZ+bC1aadewQvhDH5N6t/3m2Iht99M/JzFbrdSnAd1sS06Jd9Sq82WDLtIzlChNvxvZ5Hwxbq7mwj9p2lW5IB5RP2UouUDRbKHBwXeqiIhRJBhos6OikhboyEibElZjACyCGnu3yEG3gKPTxfzRo0SQvkm/o+b2xNcI8tEFcmGjZA/lQ28PLO8+tJZViZF0cVibRCI+k3YLIYjXK6vrcAUtJjqe1AOT2R0q42hoWCDhgIh1oTSHlicd14WWA6xxCDGBgDyCG9PT8M5hPj2fJycWqucZbc9SZkXJ5ZciG5s/vbkJVdvzRWThGEH3E2jU43044rmXBqJ9L
+  template:
+    metadata:
+      creationTimestamp: null
+      name: cloudflare-api-token
+      namespace: cert-manager

--- a/infrastructure/cert-manager/letsencrypt-issuer.yaml
+++ b/infrastructure/cert-manager/letsencrypt-issuer.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # Let's Encrypt production server
+    server: https://acme-v02.api.letsencrypt.org/directory
+
+    # Email for urgent renewal and security notices
+    email: quantum-discharge@protonmail.com
+
+    # Secret to store ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+
+    # DNS-01 challenge via Cloudflare
+    solvers:
+    - dns01:
+        cloudflare:
+          email: Alushanov92@gmail.com
+          apiTokenSecretRef:
+            name: cloudflare-api-token
+            key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # Let's Encrypt staging server (for testing)
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+
+    email: quantum-discharge@protonmail.com
+
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+
+    solvers:
+    - dns01:
+        cloudflare:
+          email: Alushanov92@gmail.com
+          apiTokenSecretRef:
+            name: cloudflare-api-token
+            key: api-token


### PR DESCRIPTION
## Summary

Add cert-manager deployment with Let's Encrypt ClusterIssuers using Cloudflare DNS-01 challenge.

## Configuration

**cert-manager Helm Chart:**
- Repository: `https://charts.jetstack.io`
- Chart: `cert-manager`
- Version: `v1.16.2`
- CRDs enabled
- Resource limits configured

**Let's Encrypt ClusterIssuers:**
- ✅ Production: `letsencrypt-prod`
- ✅ Staging: `letsencrypt-staging` (for testing)
- ✅ DNS-01 challenge via Cloudflare
- ✅ Domain: `*.ops.last-try.org`

**Secrets:**
- ✅ Cloudflare API token (SealedSecret)
- ✅ Let's Encrypt account keys (auto-generated)

**Emails:**
- Let's Encrypt notifications: `quantum-discharge@protonmail.com`
- Cloudflare account: `Alushanov92@gmail.com`

## What Happens After Merge

1. ArgoCD deploys cert-manager to `cert-manager` namespace
2. Sealed Secrets controller decrypts Cloudflare API token
3. Both ClusterIssuers become available for certificate requests
4. Ready to create TLS certificates for services

## Verification

After merge, check deployment:
```bash
kubectl get pods -n cert-manager
kubectl get clusterissuer
kubectl get secret -n cert-manager cloudflare-api-token
```

## Next Steps

1. Merge this PR
2. Next PR: Create ArgoCD Ingress with TLS certificate

🤖 Generated with [Claude Code](https://claude.com/claude-code)