### PR TITLE
feat: add ArgoCD Ingress with TLS

### DIFF
--- a/apps/infrastructure/argocd-ingress.yaml
+++ b/apps/infrastructure/argocd-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-ingress
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hitchai-app/gitops
+    path: infrastructure/argocd
+    targetRevision: master
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infrastructure/argocd/ingress.yaml
+++ b/infrastructure/argocd/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - argocd.ops.last-try.org
+    secretName: argocd-server-tls
+  rules:
+  - host: argocd.ops.last-try.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              name: http


### PR DESCRIPTION
## Summary

Add Ingress for ArgoCD server with automatic TLS certificate from Let's Encrypt.

## Configuration

**Ingress:**
- Host: `argocd.ops.last-try.org`
- IngressClass: `traefik`
- TLS: Let's Encrypt via `letsencrypt-prod` ClusterIssuer
- Certificate: Auto-managed by cert-manager

**DNS-01 Challenge:**
- Cloudflare DNS provider
- Automatic certificate issuance and renewal

## What Happens After Merge

1. ArgoCD deploys Ingress resource
2. cert-manager creates Certificate request
3. Let's Encrypt validates via Cloudflare DNS-01
4. Certificate issued and stored in `argocd-server-tls` secret
5. Traefik terminates TLS with the certificate

## Access

After merge, ArgoCD UI will be accessible at:
**https://argocd.ops.last-try.org**

## Prerequisites

**DNS Configuration Required:**
Create DNS A record in Cloudflare:
```
argocd.ops.last-try.org → <Traefik LoadBalancer IP>
```

Get LoadBalancer IP:
```bash
kubectl get svc -n traefik traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
```

## Verification

After merge, check:
```bash
# Certificate issued
kubectl get certificate -n argocd

# Ingress created
kubectl get ingress -n argocd

# Access UI
curl -I https://argocd.ops.last-try.org
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)