### PR TITLE
feat: add MetalLB LoadBalancer for bare metal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ See @adr/0010-gitops-repository-structure.md for details.
 - **Certificates**: cert-manager + Let's Encrypt DNS-01 (@adr/0008-cert-manager-for-tls.md)
 - **Secrets**: Sealed Secrets BYOK (@adr/0009-secrets-management-strategy.md)
 - **Ingress**: Traefik (@adr/0011-traefik-ingress-controller.md)
+- **LoadBalancer**: MetalLB Layer 2 (@adr/0012-metallb-load-balancer.md)
 
 ## Environments
 
@@ -69,6 +70,7 @@ All major architectural decisions are documented in `adr/`:
 - @adr/0009-secrets-management-strategy.md
 - @adr/0010-gitops-repository-structure.md
 - @adr/0011-traefik-ingress-controller.md
+- @adr/0012-metallb-load-balancer.md
 
 See @adr/README.md for ADR format guidelines.
 

--- a/adr/0012-metallb-load-balancer.md
+++ b/adr/0012-metallb-load-balancer.md
@@ -1,0 +1,102 @@
+# 0012. MetalLB for LoadBalancer on Bare Metal
+
+**Status**: Accepted
+
+**Date**: 2025-10-06
+
+## Context
+
+Kubernetes LoadBalancer services require external IP provisioning. Cloud providers handle this automatically, but on bare metal (Hetzner dedicated server), LoadBalancer services remain stuck in `<pending>` state.
+
+Requirements:
+- Expose Traefik ingress controller externally
+- Support for future multi-node scaling
+- Minimal operational complexity
+
+Current setup: Single Hetzner dedicated server (will scale to multi-node)
+
+## Decision
+
+We will use **MetalLB in Layer 2 mode** as our bare metal LoadBalancer implementation.
+
+Configuration:
+- Layer 2 mode (ARP-based)
+- IP pool: Server's main IP initially
+- When scaling: Add floating IP for automatic failover
+
+## Alternatives Considered
+
+### 1. kube-vip
+- **Pros**: Lightweight, good for control plane HA
+- **Cons**: Primarily for control plane, MetalLB better for service LoadBalancing
+- **Why not chosen**: MetalLB is standard for service LoadBalancing on bare metal
+
+### 2. NodePort (no LoadBalancer)
+- **Pros**: Simple, no additional components
+- **Cons**: Ugly URLs with ports, no automatic failover, non-standard
+- **Why not chosen**: LoadBalancer type is standard Kubernetes pattern
+
+### 3. BGP mode (MetalLB)
+- **Pros**: True load balancing across nodes
+- **Cons**: Requires BGP-capable router (Hetzner doesn't provide)
+- **Why not chosen**: Layer 2 sufficient for our scale
+
+## Consequences
+
+### Positive
+- ✅ Standard LoadBalancer service type works
+- ✅ Automatic IP assignment to services
+- ✅ Scales to multi-node with automatic failover
+- ✅ Industry standard (CNCF project)
+- ✅ Can share single IP across services (different ports)
+
+### Negative
+- ⚠️ Layer 2 mode: one node handles all traffic per IP (leader election)
+- ⚠️ ~10 second failover on node failure
+- ⚠️ Not true load balancing (all traffic through leader node)
+
+### Neutral
+- Single node: No failover benefit yet (only 1 node)
+- Multi-node: Can use floating IP for cleaner failover
+
+## Implementation Notes
+
+### Single Node Phase (Current)
+```yaml
+addresses:
+- <server-ip>/32  # Main server IP
+```
+
+### Multi-Node Phase (Future)
+```yaml
+# Option A: Use node IPs (free)
+addresses:
+- <node1-ip>/32
+- <node2-ip>/32
+
+# Option B: Use floating IP (recommended, ~€1/month)
+addresses:
+- <floating-ip>/32  # Automatic failover, no DNS changes
+```
+
+**Recommendation:** Start with server IP, add floating IP when scaling to multi-node.
+
+## Layer 2 Mode Behavior
+
+- MetalLB responds to ARP requests claiming ownership of LoadBalancer IPs
+- Leader election: one node per IP handles all traffic
+- On leader failure: standby node takes over (~10 seconds)
+- IP sharing: Multiple services can share same IP (different ports)
+
+## When to Reconsider
+
+**Revisit if:**
+1. Need true load balancing across nodes (consider external LB or BGP if available)
+2. Layer 2 failover too slow (10s) for requirements
+3. Scale beyond 5 nodes (consider BGP mode or cloud migration)
+
+## References
+
+- [MetalLB Documentation](https://metallb.universe.tf/)
+- [Layer 2 Mode](https://metallb.universe.tf/concepts/layer2/)
+- [Hetzner Additional IPs](https://docs.hetzner.com/robot/dedicated-server/ip/additional-ip-adresses/)

--- a/apps/infrastructure/metallb-config.yaml
+++ b/apps/infrastructure/metallb-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb-config
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hitchai-app/gitops
+    path: infrastructure/metallb
+    targetRevision: master
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: metallb-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/apps/infrastructure/metallb.yaml
+++ b/apps/infrastructure/metallb.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://metallb.github.io/metallb
+    chart: metallb
+    targetRevision: 0.15.2
+    helm:
+      valuesObject:
+        # Resource limits
+        controller:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
+        speaker:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: metallb-system
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/infrastructure/metallb/config.yaml
+++ b/infrastructure/metallb/config.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 88.99.214.26/32
+  autoAssign: true
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default-pool


### PR DESCRIPTION
## Summary

Add MetalLB LoadBalancer implementation for bare metal Kubernetes with Layer 2 mode.

## Components

**MetalLB Controller + Speaker:**
- Version: 0.15.2 (latest stable)
- Resource limits configured
- Deployed to `metallb-system` namespace

**Configuration:**
- IPAddressPool: `88.99.214.26/32` (server IP)
- L2Advertisement: Layer 2 mode (ARP-based)
- Auto-assign enabled

## What Happens After Merge

1. MetalLB controller and speaker deployed
2. IPAddressPool and L2Advertisement created
3. Traefik LoadBalancer service gets external IP (88.99.214.26)
4. ArgoCD Ingress becomes accessible

## Verification

After merge, check:
```bash
# MetalLB pods running
kubectl get pods -n metallb-system

# IPAddressPool created
kubectl get ipaddresspool -n metallb-system

# Traefik gets external IP
kubectl get svc -n traefik traefik
```

Expected: Traefik service shows `EXTERNAL-IP: 88.99.214.26`

## DNS Configuration

After Traefik gets IP, create DNS record:
```
argocd.ops.last-try.org → 88.99.214.26
```

Then ArgoCD UI will be accessible at `https://argocd.ops.last-try.org`

## References

- ADR 0012: MetalLB for LoadBalancer on Bare Metal

🤖 Generated with [Claude Code](https://claude.com/claude-code)