### PR TITLE
fix: add HTTP to HTTPS redirect for ArgoCD Ingress

### DIFF
--- a/infrastructure/argocd/ingress.yaml
+++ b/infrastructure/argocd/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/redirect-to-https: "true"
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Problem

HTTP requests to ArgoCD return 404:
```bash
$ curl -I http://argocd.ops.last-try.org
HTTP/1.1 404 Not Found
```

## Solution

Add Traefik redirect annotation to automatically redirect HTTP to HTTPS.

## Changes

```yaml
annotations:
  traefik.ingress.kubernetes.io/redirect-to-https: "true"
```

## After Merge

```bash
$ curl -I http://argocd.ops.last-try.org
HTTP/1.1 301 Moved Permanently
Location: https://argocd.ops.last-try.org
```

Users accessing via HTTP will be automatically redirected to HTTPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)