### PR TITLE
feat: add global HTTP to HTTPS redirect in Traefik

### DIFF
--- a/apps/infrastructure/traefik.yaml
+++ b/apps/infrastructure/traefik.yaml
@@ -20,6 +20,12 @@ spec:
         service:
           type: LoadBalancer
 
+        # Global HTTP to HTTPS redirect
+        ports:
+          web:
+            redirectTo:
+              port: websecure
+
         # Resource limits
         resources:
           requests:

--- a/infrastructure/argocd/ingress.yaml
+++ b/infrastructure/argocd/ingress.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/redirect-to-https: "true"
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Summary

Configure Traefik to automatically redirect all HTTP traffic to HTTPS using global entrypoint configuration.

## Changes

- Add `ports.web.redirectTo: websecure` in Traefik Helm values for global redirect
- Remove non-working `traefik.ingress.kubernetes.io/redirect-to-https: "true"` annotation from ArgoCD Ingress
- Clean up redundant `traefik.ingress.kubernetes.io/router.tls: "true"` annotation

## Why

The per-Ingress annotation doesn't work in Traefik. Global configuration at the entrypoint level ensures all services automatically get HTTP→HTTPS redirect without needing per-service middleware or annotations.

## Test Plan

After merge:
- [ ] Test HTTP redirect: `curl -I http://argocd.ops.last-try.org/` (should 301/302 to HTTPS)
- [ ] Verify HTTPS still works: `curl -I https://argocd.ops.last-try.org/` (should 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)