### PR TITLE
fix: defaultReplicaCount must be string in Longhorn config

### DIFF
--- a/apps/infrastructure/longhorn-operator.yaml
+++ b/apps/infrastructure/longhorn-operator.yaml
@@ -13,7 +13,7 @@ spec:
       valuesObject:
         # Default replica count (single node configuration)
         defaultSettings:
-          defaultReplicaCount: 1
+          defaultReplicaCount: "1"
           backupTarget: "s3://longhorn-backups@auto/"
           backupTargetCredentialSecret: "longhorn-backup-secret"
 


### PR DESCRIPTION
## Problem

Longhorn operator ArgoCD application failing with:

```
Error: defaultSettings.defaultReplicaCount must be a string
```

## Fix

Change `defaultReplicaCount: 1` to `defaultReplicaCount: "1"`

Helm validation requires string type for this parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)