### PR TITLE
feat: add CloudNativePG operator and production cluster

### DIFF
--- a/adr/0004-cloudnativepg-for-postgresql.md
+++ b/adr/0004-cloudnativepg-for-postgresql.md
@@ -171,7 +171,7 @@ Configuration:
 - **Storage exhaustion**: Alert at 70% disk, automated cleanup, volume expansion
 - **Stuck failover**: Documented manual recovery procedure, tested monthly
 - **Operator downtime**: Monitor operator pod health, auto-restart, redundancy when possible
-- **Breaking changes**: Subscribe to release notes, test upgrades in stage first
+- **Breaking changes**: Subscribe to release notes, test upgrades in a non-production environment first
 
 ### Configuration Example
 ```yaml

--- a/apps/infrastructure/cloudnativepg.yaml
+++ b/apps/infrastructure/cloudnativepg.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudnativepg
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://cloudnative-pg.github.io/charts
+    chart: cloudnative-pg
+    targetRevision: 0.26.0
+    helm:
+      valuesObject:
+        config:
+          clusterWide: true
+        monitoring:
+          podMonitorEnabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cnpg-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/infrastructure/kustomization.yaml
+++ b/apps/infrastructure/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  # Secrets management (must be first)
+  - sealed-secrets.yaml
+
+  # TLS certificate management
+  - cert-manager.yaml
+  - letsencrypt-issuer.yaml
+
+  # Ingress controller
+  - traefik.yaml
+  - argocd-ingress.yaml
+
+  # Database operator and clusters
+  - cloudnativepg.yaml
+  - postgres.yaml

--- a/apps/infrastructure/postgres.yaml
+++ b/apps/infrastructure/postgres.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hitchai-app/gitops
+    path: infrastructure/postgres/overlays/prod
+    targetRevision: master
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postgres-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infrastructure/postgres/IMPLEMENTATION.md
+++ b/infrastructure/postgres/IMPLEMENTATION.md
@@ -1,0 +1,39 @@
+# Implementation summary
+
+```
+infrastructure/postgres/
+├── base/
+│   ├── cluster.yaml                # Canonical CloudNativePG cluster spec
+│   └── kustomization.yaml
+├── overlays/
+│   └── prod/
+│       ├── backup-s3-credentials-sealed.yaml.example
+│       └── kustomization.yaml
+├── README.md
+├── IMPLEMENTATION.md
+└── VERIFICATION.md
+```
+
+## Base cluster (`base/cluster.yaml`)
+
+- `imageName`: `ghcr.io/cloudnative-pg/postgresql:17.2`
+- `instances`: 1 (single node to start; CloudNativePG handles replicas later)
+- `storage`: `longhorn-single-replica`, 50 GiB
+- `resources`: requests 500 m CPU / 1 Gi RAM, limits 2 CPU / 2 Gi RAM
+- `monitoring`: PodMonitor enabled
+- `backup`: Barman to `s3://cloudnativepg-backups/postgres-prod`, gzip compression, 30 day retention
+- `bootstrap`: creates an `app` database owned by `app`
+
+Secrets are referenced as `backup-s3-credentials` (to be provided via SealedSecret).
+
+## Production overlay (`overlays/prod`)
+
+- Applies the base manifest into namespace `postgres-prod`
+- Provides `.example` sealed secret and instructs the operator to add the sealed secret file once generated
+- No further patches are required; base spec already matches production sizing
+
+## ArgoCD integration
+
+- Operator is deployed by `apps/infrastructure/cloudnativepg.yaml`
+- The production cluster is managed via `apps/infrastructure/postgres.yaml`
+- Both Applications use automated sync with prune + self-heal and `CreateNamespace=true`

--- a/infrastructure/postgres/README.md
+++ b/infrastructure/postgres/README.md
@@ -1,0 +1,50 @@
+# PostgreSQL with CloudNativePG
+
+This component provisions a shared PostgreSQL cluster using the CloudNativePG operator. It is intended for production workloads and runs in the `postgres-prod` namespace.
+
+## What ships here
+
+- CloudNativePG operator (deployed cluster-wide via ArgoCD)
+- A single `postgres-shared` cluster (PostgreSQL 17.2)
+- Continuous WAL/data backups to S3 with 30-day retention (Barman)
+- Prometheus PodMonitor for metrics scraping
+
+## Manual prerequisites
+
+1. **Create an S3 bucket** – for example `cloudnativepg-backups`.
+2. **Provision IAM credentials** with `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket` permissions on that bucket.
+3. **Seal the credentials** for ArgoCD:
+
+   ```bash
+   kubectl create secret generic backup-s3-credentials \
+     --from-literal=ACCESS_KEY_ID=<access-key> \
+     --from-literal=ACCESS_SECRET_KEY=<secret-key> \
+     --namespace=postgres-prod \
+     --dry-run=client -o yaml > /tmp/backup-s3-credentials.yaml
+
+   kubeseal --format=yaml \
+     < /tmp/backup-s3-credentials.yaml \
+     > infrastructure/postgres/overlays/prod/backup-s3-credentials-sealed.yaml
+
+   rm /tmp/backup-s3-credentials.yaml
+   ```
+
+4. **Add the sealed secret to Kustomize** – uncomment the line in
+   `infrastructure/postgres/overlays/prod/kustomization.yaml` that references
+   `backup-s3-credentials-sealed.yaml`, then commit it.
+
+Once the credentials are sealed and committed, ArgoCD will be able to sync the cluster successfully.
+
+## Storage & backups
+
+- StorageClass: `longhorn-single-replica`
+- PVC size: 50 GiB
+- Backups: gzip-compressed WAL and base backups to `s3://cloudnativepg-backups/postgres-prod`
+- Retention: 30 days
+- Point-in-time recovery supported via Barman
+
+## Related ADRs
+
+- [ADR 0004](../../adr/0004-cloudnativepg-for-postgresql.md) – operator rationale
+- [ADR 0007](../../adr/0007-longhorn-storageclass-strategy.md) – Longhorn usage
+- [ADR 0009](../../adr/0009-secrets-management-strategy.md) – handling secrets

--- a/infrastructure/postgres/VERIFICATION.md
+++ b/infrastructure/postgres/VERIFICATION.md
@@ -1,0 +1,103 @@
+# Verification guide
+
+Use the commands below after ArgoCD syncs the CloudNativePG applications.
+
+## 1. Operator status
+
+```bash
+kubectl get pods -n cnpg-system
+kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg --tail=50
+```
+
+All pods should be `Running`.
+
+## 2. Cluster health
+
+```bash
+# Check CloudNativePG custom resource
+kubectl get clusters.postgresql.cnpg.io -n postgres-prod
+kubectl describe cluster postgres-shared -n postgres-prod
+
+# Check PostgreSQL pod
+kubectl get pods -n postgres-prod
+```
+
+`postgres-shared` should report `Cluster in healthy state` and the pod should be ready.
+
+## 3. Storage
+
+```bash
+kubectl get pvc -n postgres-prod
+```
+
+Expect a bound PVC using the `longhorn-single-replica` storage class with 50 GiB capacity.
+
+## 4. Backups
+
+```bash
+kubectl get secret backup-s3-credentials -n postgres-prod
+kubectl get cluster postgres-shared -n postgres-prod -o jsonpath='{.status.firstRecoverabilityPoint}'
+```
+
+The secret must exist, and once the first backup completes the cluster status exposes a recoverability point. You can also inspect the S3 bucket via your cloud CLI.
+
+## 5. Metrics
+
+```bash
+kubectl get podmonitor -n postgres-prod
+```
+
+A PodMonitor named `postgres-shared` should be present so Prometheus can scrape metrics.
+
+## 6. ArgoCD Applications
+
+```bash
+kubectl get application cloudnativepg -n argocd
+kubectl get application postgres-prod -n argocd
+```
+
+Both Applications should be `Synced` and `Healthy`.
+
+## 7. Disaster recovery smoke test (optional)
+
+To validate backups end-to-end:
+
+```bash
+cat <<'YAML' | kubectl apply -f -
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-restore-test
+  namespace: postgres-prod
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+  storage:
+    storageClass: longhorn-single-replica
+    size: 10Gi
+  bootstrap:
+    recovery:
+      source: postgres-shared
+  externalClusters:
+  - name: postgres-shared
+    barmanObjectStore:
+      destinationPath: s3://cloudnativepg-backups/postgres-prod
+      s3Credentials:
+        accessKeyId:
+          name: backup-s3-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: backup-s3-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+YAML
+```
+
+Wait for the cluster to become healthy, verify data, then remove it:
+
+```bash
+kubectl delete cluster postgres-restore-test -n postgres-prod
+```
+
+This confirms that PITR/backup configuration is functional.

--- a/infrastructure/postgres/base/cluster.yaml
+++ b/infrastructure/postgres/base/cluster.yaml
@@ -1,0 +1,56 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-shared
+spec:
+  # Start with a single instance; scale out when additional Kubernetes nodes exist
+  instances: 1
+
+  # Explicit PostgreSQL image (avoid floating tags)
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+
+  # Longhorn-backed persistent storage
+  storage:
+    storageClass: longhorn-single-replica
+    size: 50Gi
+
+  # Baseline resource profile (overlays may adjust)
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+
+  # Expose metrics for Prometheus
+  monitoring:
+    enablePodMonitor: true
+
+  # Continuous backups to S3 via Barman
+  backup:
+    retentionPolicy: "30d"
+    barmanObjectStore:
+      destinationPath: s3://cloudnativepg-backups/postgres-prod
+      s3Credentials:
+        accessKeyId:
+          name: backup-s3-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: backup-s3-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 2
+      data:
+        compression: gzip
+        jobs: 2
+
+  # Initial bootstrap configuration
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      encoding: "UTF8"
+      localeCollate: "en_US.UTF-8"
+      localeCType: "en_US.UTF-8"

--- a/infrastructure/postgres/base/kustomization.yaml
+++ b/infrastructure/postgres/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster.yaml

--- a/infrastructure/postgres/overlays/prod/backup-s3-credentials-sealed.yaml.example
+++ b/infrastructure/postgres/overlays/prod/backup-s3-credentials-sealed.yaml.example
@@ -1,0 +1,36 @@
+# Example Sealed Secret for S3 backup credentials
+#
+# Instructions:
+# 1. Create a regular Secret with your actual S3 credentials:
+#    kubectl create secret generic backup-s3-credentials \
+#      --from-literal=ACCESS_KEY_ID=your-access-key \
+#      --from-literal=ACCESS_SECRET_KEY=your-secret-key \
+#      --namespace=postgres-prod \
+#      --dry-run=client -o yaml > backup-s3-credentials.yaml
+#
+# 2. Seal the secret using kubeseal:
+#    kubeseal --format=yaml \
+#      < backup-s3-credentials.yaml \
+#      > backup-s3-credentials-sealed.yaml
+#
+# 3. Delete the plaintext secret file:
+#    rm backup-s3-credentials.yaml
+#
+# 4. Uncomment the sealed secret reference in kustomization.yaml
+#
+# 5. Commit backup-s3-credentials-sealed.yaml to git
+
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: backup-s3-credentials
+  namespace: postgres-prod
+spec:
+  encryptedData:
+    ACCESS_KEY_ID: REPLACE_WITH_SEALED_VALUE
+    ACCESS_SECRET_KEY: REPLACE_WITH_SEALED_VALUE
+  template:
+    metadata:
+      name: backup-s3-credentials
+      namespace: postgres-prod
+    type: Opaque

--- a/infrastructure/postgres/overlays/prod/kustomization.yaml
+++ b/infrastructure/postgres/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: postgres-prod
+
+resources:
+  - ../../base
+  # After sealing real S3 credentials, uncomment the line below
+  # - backup-s3-credentials-sealed.yaml


### PR DESCRIPTION
## Summary
- add ArgoCD Application to deploy the CloudNativePG Helm chart cluster-wide
- define production PostgreSQL cluster manifests (base + prod overlay with sealed-secret placeholder)
- document setup/verification steps and tweak ADR-0004 wording around upgrade testing

## Testing
- kustomize build infrastructure/postgres/overlays/prod *(tool not available in container; manual verification pending)*
