### PR TITLE
docs: add StorageClass migration guidance to ADR 0007

### DIFF
--- a/adr/0007-longhorn-storageclass-strategy.md
+++ b/adr/0007-longhorn-storageclass-strategy.md
@@ -110,6 +110,13 @@ After systematic investigation, we discovered TWO issues preventing CSIStorageCa
 - Single node: All classes use 1 replica (only 1 node available)
 - Multi-node: Replicated class increases to 3 replicas for redundancy across nodes
 
+### StorageClass Updates and Volume Migration
+
+- Only metadata (labels/annotations, including default-class toggles) is mutable in-place. Kubernetes validation rejects spec edits to `parameters`, `provisioner`, `reclaimPolicy`, or `volumeBindingMode`, so changing the class configuration requires deleting and re-applying the `StorageClass` manifest ([Kubernetes storage validation](https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/apis/storage/validation/validation.go#L66-L86)).
+- Removing a `StorageClass` does not touch existing volumes: PersistentVolumes keep their lifecycle independent of the class object, so currently bound workloads stay online while the class is recreated, and new PVCs simply fail until the resource exists again ([Kubernetes PersistentVolume lifecycle](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim)).
+- Longhorn only reads `parameters` when provisioning a new volume. Updating a `StorageClass` later does not retrofit values onto existing Longhorn volumes, so plan follow-up actions for workloads that should inherit the new defaults ([Longhorn storage-class parameters](https://longhorn.io/docs/1.10.0/references/storage-class-parameters/)).
+- Replication characteristics can be raised post-provisioning without recreating PVCs: adjust `spec.numberOfReplicas` (or related per-volume settings) through the Longhorn UI/CRD and Longhorn will create the additional replicas, re-balancing them as the cluster grows ([Longhorn replica auto-balance](https://longhorn.io/docs/1.10.0/high-availability/auto-balance-replicas/)).
+
 ## When to Reconsider
 
 **Revisit if:**
@@ -124,5 +131,9 @@ After systematic investigation, we discovered TWO issues preventing CSIStorageCa
 - [Longhorn CSIStorageCapacity Issue #10685](https://github.com/longhorn/longhorn/issues/10685) - Feature request and implementation
 - [Longhorn v1.10.0 Release Notes](https://github.com/longhorn/longhorn/releases/tag/v1.10.0) - CSIStorageCapacity mentioned
 - [Kubernetes Storage Capacity Tracking](https://kubernetes-csi.github.io/docs/storage-capacity-tracking.html)
+- [Kubernetes storage validation](https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/apis/storage/validation/validation.go#L66-L86)
+- [Kubernetes PersistentVolume lifecycle](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim)
+- [Longhorn storage-class parameters](https://longhorn.io/docs/1.10.0/references/storage-class-parameters/)
+- [Longhorn replica auto-balance](https://longhorn.io/docs/1.10.0/high-availability/auto-balance-replicas/)
 - ADR 0002: Longhorn Storage from Day One
 - ADR 0004: CloudNativePG for PostgreSQL

--- a/infrastructure/longhorn/storageclass-refresh-runbook.md
+++ b/infrastructure/longhorn/storageclass-refresh-runbook.md
@@ -1,0 +1,32 @@
+# Longhorn StorageClass Refresh
+
+**Goal:** apply immutable spec changes by deleting the live class and letting ArgoCD recreate it.
+
+## Prep
+- Confirm manifests in `infrastructure/longhorn/` and ADR 0007 show the desired spec.
+- Ensure you can `kubectl delete storageclass <name>`.
+- Consider a brief freeze on new PVC creation (default class is unavailable during the gap).
+
+## Steps
+1. (Optional) Pause Argo auto-sync if you want manual timing.
+2. Delete the classes:
+   ```
+   kubectl delete storageclass replicated
+   kubectl delete storageclass single-replica
+   kubectl delete storageclass ephemeral
+   ```
+   Existing PVs stay Bound; only new PVCs pause.
+3. Let Argo resync (auto or manual). If needed, `kubectl apply -f infrastructure/longhorn/<file>.yaml`.
+4. Re-enable auto-sync if you paused it.
+
+## Verify
+- `kubectl get storageclass`
+- `kubectl get pv -A --sort-by=.spec.storageClassName`
+- `kubectl apply --dry-run=server -f infrastructure/longhorn/storageclass-replicated.yaml`
+- ArgoCD UI shows Healthy/Synced
+
+## References
+- ADR 0007 – [Longhorn StorageClass Strategy](../../adr/0007-longhorn-storageclass-strategy.md)
+- Kubernetes – [PersistentVolume lifecycle](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim)
+- Kubernetes – [StorageClass validation code](https://github.com/kubernetes/kubernetes/blob/v1.30.0/pkg/apis/storage/validation/validation.go#L66-L86)
+- Longhorn – [Storage-class parameters](https://longhorn.io/docs/1.10.0/references/storage-class-parameters/)


### PR DESCRIPTION
## Summary

- Documents StorageClass immutability constraints (only metadata can be edited in-place)
- Explains that PersistentVolumes remain independent when StorageClass is deleted/recreated
- Clarifies that Longhorn only reads parameters during volume provisioning
- Documents the path for scaling replicas as the cluster grows to multi-node
- Adds operational runbook for safely refreshing StorageClass specs

## Context

ADR 0007 previously documented the strategic choice of multiple StorageClasses but didn't explain the operational reality that spec changes require delete/recreate cycles. This guidance emerged from investigating CSIStorageCapacity issues and understanding Kubernetes StorageClass validation.

## Changes

- **ADR 0007**: New "StorageClass Updates and Volume Migration" section with four key points
- **New runbook**: `infrastructure/longhorn/storageclass-refresh-runbook.md` with step-by-step procedure

## Test Plan

- [x] Verified references link to correct upstream documentation
- [x] Runbook steps validated against Kubernetes 1.30 behavior
- [x] Guidance aligns with Longhorn 1.10.0 capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)