### PR TITLE
fix: disable CloudNativePG PodMonitor until Prometheus Operator installed

### DIFF
--- a/apps/infrastructure/cloudnativepg.yaml
+++ b/apps/infrastructure/cloudnativepg.yaml
@@ -14,7 +14,7 @@ spec:
         config:
           clusterWide: true
         monitoring:
-          podMonitorEnabled: true
+          podMonitorEnabled: false
   destination:
     server: https://kubernetes.default.svc
     namespace: cnpg-system


### PR DESCRIPTION
## Summary

Disables `podMonitorEnabled` in CloudNativePG configuration to resolve sync failure.

## Problem

CloudNativePG application is stuck in OutOfSync/Missing status with sync errors:
```
Failed sync attempt: one or more synchronization tasks are not valid
```

The root cause is that the Helm chart tries to create a PodMonitor resource (monitoring.coreos.com/v1) but Prometheus Operator CRDs are not installed on the cluster.

## Solution

Set `monitoring.podMonitorEnabled: false` until Prometheus Operator stack is deployed.

## Changes

- `apps/infrastructure/cloudnativepg.yaml`: Set `podMonitorEnabled: false`

## Verification Steps

After merge, ArgoCD should:
1. Sync successfully without PodMonitor errors
2. Deploy CloudNativePG operator to cnpg-system namespace
3. Show Healthy status

## Future Work

Re-enable PodMonitor after deploying:
- Prometheus Operator
- ServiceMonitor/PodMonitor CRDs
- Monitoring infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)