### PR TITLE
fix(arc): scope oci repo urls to charts

### DIFF
--- a/apps/infrastructure/arc-controller.yaml
+++ b/apps/infrastructure/arc-controller.yaml
@@ -7,8 +7,7 @@ spec:
   project: default
   sources:
     # Helm chart from OCI registry (ghcr.io)
-    - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts
-      chart: gha-runner-scale-set-controller
+    - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
       targetRevision: 0.12.1
       helm:
         releaseName: arc

--- a/apps/infrastructure/arc-runners.yaml
+++ b/apps/infrastructure/arc-runners.yaml
@@ -7,8 +7,7 @@ spec:
   project: default
   sources:
     # Helm chart from OCI registry (ghcr.io)
-    - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts
-      chart: gha-runner-scale-set
+    - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
       targetRevision: 0.12.1
       helm:
         releaseName: hitchai-app-runners


### PR DESCRIPTION
## Summary
- embed the chart path directly in the ARC controller and runner OCI repoURLs so ArgoCD requests the correct GHCR artifact
- drop the separate `chart` fields to match the path-based workaround ArgoCD expects today

## Testing
- not run (manifest-only change)

## Follow-up
- force-refresh `arc-controller` and `arc-runners` applications to confirm the 403 clears