### PR TITLE
fix(arc): set oci chart path

### DIFF
--- a/apps/infrastructure/arc-controller.yaml
+++ b/apps/infrastructure/arc-controller.yaml
@@ -8,6 +8,7 @@ spec:
   sources:
     # Helm chart from OCI registry (ghcr.io)
     - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+      path: .
       targetRevision: 0.12.1
       helm:
         releaseName: arc

--- a/apps/infrastructure/arc-runners.yaml
+++ b/apps/infrastructure/arc-runners.yaml
@@ -8,6 +8,7 @@ spec:
   sources:
     # Helm chart from OCI registry (ghcr.io)
     - repoURL: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+      path: .
       targetRevision: 0.12.1
       helm:
         releaseName: hitchai-app-runners


### PR DESCRIPTION
## Summary
- add `path: .` to the arc controller and runner OCI sources so ArgoCD accepts the chart-only repoURL

## Testing
- not run (manifest-only change)

## Follow-up
- force-refresh arc-controller and arc-runners once merged