### PR TITLE
fix(arc): point runner chart at controller serviceaccount

### DIFF
--- a/infrastructure/arc-runners/hitchai-app/values.yaml
+++ b/infrastructure/arc-runners/hitchai-app/values.yaml
@@ -32,3 +32,8 @@ template:
       emptyDir:
         medium: Memory
         sizeLimit: 2Gi
+
+# Explicitly link this scale set to the controller the chart failed to discover automatically.
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-gha-rs-controller


### PR DESCRIPTION
## Summary
- set controllerServiceAccount.name/namespace for the gha-runner-scale-set so Helm can bind to the existing controller in arc-systems

## Testing
- not run (manifest-only change)

## Follow-up
- force-refresh arc-runners after merge to verify the RoleBinding renders and syncs cleanly