### PR TITLE
fix(arc): use githubConfigSecret field

### DIFF
--- a/infrastructure/arc-runners/hitchai-app/values.yaml
+++ b/infrastructure/arc-runners/hitchai-app/values.yaml
@@ -2,7 +2,7 @@
 
 # Required: GitHub configuration
 githubConfigUrl: "https://github.com/hitchai-app"
-existingSecret: "hitchai-app-github-app"
+githubConfigSecret: "hitchai-app-github-app"
 
 # Scaling (default: minRunners=0, maxRunners=unlimited)
 maxRunners: 4


### PR DESCRIPTION
## Summary
- switch the gha-runner scale-set values to populate \ so the chart renders the GitHub auth secret correctly

## Testing
- not run (manifest-only change)

## Follow-up
- re-sync arc-runners after merge; the chart should now template without the secret discovery error