### PR TITLE
fix(arc): enable server-side apply for controller crds

### DIFF
--- a/apps/infrastructure/arc-controller.yaml
+++ b/apps/infrastructure/arc-controller.yaml
@@ -27,6 +27,7 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+    - ServerSideApply=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## Summary
- add  sync option so ArgoCD renders the ARC controller CRDs without tripping the 256 KiB annotation limit

## Testing
- not run (manifest-only change)

## Follow-up
- force-refresh arc-controller after merge to verify the sync error clears