### PR TITLE
fix(arc): drop redundant containerMode dind

### DIFF
--- a/infrastructure/arc-runners/hitchai-app/values.yaml
+++ b/infrastructure/arc-runners/hitchai-app/values.yaml
@@ -7,12 +7,10 @@ githubConfigSecret: "hitchai-app-github-app"
 # Scaling (default: minRunners=0, maxRunners=unlimited)
 maxRunners: 4
 
-# Container mode (required for Docker-in-Docker)
-containerMode:
-  type: "dind"
-
 # Runner pod template
 # Documentation: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller
+# NOTE: The ARC chart auto-populates DinD containers when containerMode.type=dind
+# (see chart values comments); we manage the sidecar explicitly here instead.
 template:
   spec:
     # In DinD mode (Kubernetes v1.29+), the dind container runs as an init container with restartPolicy: Always


### PR DESCRIPTION
## Summary
- remove  from the runner values so we rely on the explicit template we now manage
- this avoids the duplicate volume definitions Kubernetes rejected ()

## Rationale
The ARC chart already wires the DinD sidecar when  is set. Its values file notes that setting the field will populate the pod template automatically ([reference](https://github.com/actions/actions-runner-controller/blob/v0.12.1/charts/gha-runner-scale-set/values.yaml#L318-L360)). Because we render the sidecar and volumes manually (to point at the cache mirror, tweak probes, etc.), keeping  enabled double-defines the same volumes.

## Testing
- not run (manifest-only change)

## Follow-up
- resync  after merge; the AutoscalingRunnerSet should reconcile without the duplicate volume error