### PR TITLE
fix(signoz): raise clickhouse resources to stop log query OOMs

### DIFF
--- a/infrastructure/observability-signoz/values.yaml
+++ b/infrastructure/observability-signoz/values.yaml
@@ -3,9 +3,10 @@ clickhouse:
     storageClass: single-replica
     size: 30Gi
   resources:
+    # SigNoz log queries and ClickHouse merges were OOMing with the default cap
     limits:
-      cpu: 1500m
-      memory: 3Gi
+      cpu: 2000m
+      memory: 8Gi
     requests:
-      cpu: 300m
-      memory: 1536Mi
+      cpu: 500m
+      memory: 4Gi


### PR DESCRIPTION
## Summary
- increase ClickHouse CPU/memory to stop `internal: failed to get logs keys` errors caused by `MEMORY_LIMIT_EXCEEDED`
- document why higher limits are required so future reviewers know this trade-off

## Testing
- `kubectl logs signoz-0 -n observability-signoz --since=1h`
- `kubectl exec chi-signoz-clickhouse-cluster-0-0-0 -n observability-signoz -- clickhouse-client --query "select count() from signoz_logs.logs_v2 where timestamp >= now() - interval 5 minute"`
