### PR TITLE
fix(gitlab): move gitaly.enabled to global scope and fix storageClass

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -63,6 +63,10 @@ global:
   minio:
     enabled: false
 
+  # Gitaly enabled at global level (required by chart 9.x)
+  gitaly:
+    enabled: true
+
   # Object storage configuration (all buckets use external MinIO)
   appConfig:
     object_store:
@@ -146,9 +150,8 @@ gitlab:
         concurrency: 10  # Reduced from default 20
         queues: ''  # Empty = all queues
 
-  # Gitaly (Git repository storage)
+  # Gitaly (Git repository storage) - enabled via global.gitaly.enabled
   gitaly:
-    enabled: true
     resources:
       requests:
         cpu: 200m
@@ -164,7 +167,7 @@ gitlab:
           release: kube-prometheus-stack
     persistence:
       enabled: true
-      storageClass: longhorn  # Use existing Longhorn
+      storageClass: single-replica  # ADR 0007
       size: 50Gi
       accessMode: ReadWriteOnce
 
@@ -244,7 +247,7 @@ gitlab:
         schedule: "0 2 * * *"  # Daily at 2 AM
         persistence:
           enabled: true
-          storageClass: longhorn
+          storageClass: single-replica  # ADR 0007
           size: 10Gi
 
 # Container Registry


### PR DESCRIPTION
## Summary
- Move `gitlab.gitaly.enabled` to `global.gitaly.enabled` (required by GitLab Helm chart 9.x)
- Fix storageClass from `longhorn` to `single-replica` (ADR 0007) for:
  - Gitaly persistence
  - Toolbox backup persistence

## Impact Analysis
- **Services affected**: GitLab deployment
- **Breaking changes**: No
- **Database/schema changes**: No
- **Configuration changes**: Yes - values.yaml structure for gitaly configuration
- **Dependencies**: Requires GitLab Helm chart 9.6.1

## Root Cause
GitLab Helm chart 9.x removed chart-local gitaly configuration and requires it at global scope. ArgoCD sync was failing with:
```
Chart-local configuration of Gitaly features has been moved to global.
Please remove `gitlab.gitaly.enabled` from your properties, and set `global.gitaly.enabled` instead.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)