### PR TITLE
fix(gitlab): use gitlab-sshd for metrics support

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -174,6 +174,7 @@ gitlab:
   # GitLab Shell (SSH access for git)
   gitlab-shell:
     enabled: true
+    sshDaemon: gitlab-sshd  # Required for metrics support
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
## Summary
- Set `sshDaemon: gitlab-sshd` for GitLab Shell to enable metrics support

## Impact Analysis
- **Services affected**: GitLab Shell (SSH access)
- **Breaking changes**: No - gitlab-sshd is the recommended daemon
- **Configuration changes**: Yes - switches from default openssh to gitlab-sshd

## Root Cause
GitLab Helm chart 9.x validates that metrics can only be enabled with gitlab-sshd daemon:
```
gitlab-shell.metrics.enabled is true, but gitlab-shell.sshDaemon is set to "openssh".
Metrics are not supported for the "openssh".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)