### PR TITLE
fix(gitlab): disable upgradeCheck for fresh ArgoCD install

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -319,3 +319,11 @@ shared-secrets:
   env: production
   rbac:
     create: true
+
+# Upgrade Check - DISABLED for fresh install
+# ArgoCD maps Helm pre-upgrade hooks to PreSync, running them even on first install.
+# The upgrade-check job fails because gitlab-gitlab-chart-info ConfigMap doesn't exist yet.
+# See: https://github.com/argoproj/argo-cd/issues/7536
+# TODO: Re-enable after first successful deployment
+upgradeCheck:
+  enabled: false


### PR DESCRIPTION
## Summary
- Disable `upgradeCheck.enabled` for fresh GitLab installation via ArgoCD

## Impact Analysis
- **Services affected**: GitLab deployment (unblocks initial sync)
- **Breaking changes**: No
- **Configuration changes**: Yes - disables upgrade version check hook

## Root Cause
ArgoCD maps Helm `pre-upgrade` hooks to `PreSync`, causing them to run even on first install. Native Helm skips `pre-upgrade` hooks during `helm install`.

The upgrade-check job reads from `gitlab-gitlab-chart-info` ConfigMap which doesn't exist on fresh install, causing:
```
It seems you are attempting an unsupported upgrade path.
```

## References
- [ArgoCD Issue #7536](https://github.com/argoproj/argo-cd/issues/7536) - ArgoCD treats pre-upgrade as PreSync
- [GitLab Issue #2979](https://gitlab.com/gitlab-org/charts/gitlab/-/issues/2979) - upgrade check fails on first install

## Follow-up
After first successful deployment, re-enable upgradeCheck for future version upgrades (see follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)