### PR TITLE
chore(gitlab): re-enable upgradeCheck after initial deployment

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -320,10 +320,8 @@ shared-secrets:
   rbac:
     create: true
 
-# Upgrade Check - DISABLED for fresh install
-# ArgoCD maps Helm pre-upgrade hooks to PreSync, running them even on first install.
-# The upgrade-check job fails because gitlab-gitlab-chart-info ConfigMap doesn't exist yet.
-# See: https://github.com/argoproj/argo-cd/issues/7536
-# TODO: Re-enable after first successful deployment
+# Upgrade Check - Re-enabled after successful initial deployment
+# ConfigMap gitlab-gitlab-chart-info now exists, so upgrade path validation works.
+# This prevents skipping required upgrade stops (e.g., 18.2 → 18.5 → 18.8 → 18.11)
 upgradeCheck:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
## Summary
- Re-enable `upgradeCheck.enabled` after GitLab initial deployment succeeds

## Prerequisites
- [ ] GitLab initial deployment successful (PR #164 merged and synced)
- [ ] ConfigMap `gitlab-gitlab-chart-info` exists in gitlab namespace
- [ ] All GitLab pods running and healthy

## Why This Matters
The upgrade check validates version compatibility and prevents skipping required upgrade stops:
- GitLab 18 required stops: 18.2 → 18.5 → 18.8 → 18.11
- PostgreSQL version compatibility checks
- Configuration deprecation warnings

## Verification Before Merging
```bash
# Verify ConfigMap exists
kubectl get configmap gitlab-gitlab-chart-info -n gitlab

# Verify GitLab is healthy
kubectl get pods -n gitlab
```

## References
- Closes TODO from PR #164
- [GitLab Upgrade Paths](https://docs.gitlab.com/update/upgrade_paths/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)