### PR TITLE
fix(gitlab): use available MinIO image tag on quay.io

### DIFF
--- a/workloads/gitlab/minio/tenant.yaml
+++ b/workloads/gitlab/minio/tenant.yaml
@@ -7,7 +7,7 @@ metadata:
   name: gitlab-minio
   namespace: gitlab
 spec:
-  image: quay.io/minio/minio:RELEASE.2025-10-15T17-29-55Z
+  image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
 
   pools:
     - name: pool-0


### PR DESCRIPTION
## Summary
- Fix MinIO ImagePullBackOff by using tag available on quay.io

## Root Cause
`RELEASE.2025-10-15T17-29-55Z` exists on GitHub releases but hasn't been pushed to quay.io yet.

Latest available on quay.io: `RELEASE.2025-09-07T16-13-09Z`

## Verification
```bash
curl -s "https://quay.io/api/v1/repository/minio/minio/tag/?limit=5" | jq -r '.tags[].name'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)