### PR TITLE
fix(gitlab): remove unsupported rotationPolicy from Certificate

### DIFF
--- a/workloads/gitlab/certificates/gitlab-tls.yaml
+++ b/workloads/gitlab/certificates/gitlab-tls.yaml
@@ -11,4 +11,3 @@ spec:
   dnsNames:
     - gitlab.ops.last-try.org
     - registry.ops.last-try.org
-  rotationPolicy: Always


### PR DESCRIPTION
## Summary
- Remove `rotationPolicy: Always` from Certificate - not supported by cert-manager v1.16.2

## Root Cause
ArgoCD sync blocked with ComparisonError:
```
.spec.rotationPolicy: field not declared in schema
```

cert-manager v1.16.2 CRD doesn't include this field.

## Impact
- Unblocks ArgoCD sync for GitLab deployment
- Certificate will still rotate normally via renewBefore (default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)