### PR TITLE
fix(gitlab): disable Redis auth for passwordless Valkey

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -58,6 +58,8 @@ global:
   redis:
     host: gitlab-valkey
     port: 6379
+    auth:
+      enabled: false  # Valkey runs without password per ADR 0005
 
   # MinIO disabled (using object_store with dedicated tenant - ADR 0006)
   minio:


### PR DESCRIPTION
## Summary
- Add `global.redis.auth.enabled: false` for passwordless Valkey

## Root Cause
Pods stuck in Init with:
```
secret "gitlab-redis-secret" not found
```

Valkey runs without password per ADR 0005. GitLab needs explicit config to skip auth.

## Reference
- [GitLab External Redis Docs](https://docs.gitlab.com/charts/advanced/external-redis/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)