### PR TITLE
fix(gitlab): increase migrations memory to prevent OOM

### DIFF
--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -228,11 +228,11 @@ gitlab:
     enabled: true
     resources:
       requests:
-        cpu: 100m
-        memory: 200Mi
-      limits:
-        cpu: 500m
+        cpu: 200m
         memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1536Mi  # Migrations are memory-intensive
 
   # Toolbox (for backups and maintenance tasks)
   toolbox:


### PR DESCRIPTION
## Summary
- Increase migrations memory limit from 512Mi to 1536Mi

## Root Cause
Migrations pod OOM killed (exit code 137):
```
Last State: Terminated
  Reason: Error
  Exit Code: 137
```

GitLab database migrations are memory-intensive during initial setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)