### PR TITLE
fix(gitlab): disable bundled cert-manager to prevent CRD conflicts

### DIFF
--- a/workloads/gitlab/certificates/gitlab-tls.yaml
+++ b/workloads/gitlab/certificates/gitlab-tls.yaml
@@ -11,3 +11,4 @@ spec:
   dnsNames:
     - gitlab.ops.last-try.org
     - registry.ops.last-try.org
+    - kas.ops.last-try.org

--- a/workloads/gitlab/values.yaml
+++ b/workloads/gitlab/values.yaml
@@ -21,8 +21,8 @@ global:
     class: traefik
     provider: traefik  # Required for SSH support (IngressRouteTCP)
     configureCertmanager: false  # Use existing cert-manager
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Note: Do NOT add cert-manager.io/cluster-issuer annotation here
+    # It triggers auto-certificate creation which conflicts with our explicit Certificate CRD
     tls:
       enabled: true
       secretName: gitlab-tls
@@ -304,6 +304,8 @@ minio:
   install: false
 
 # Cert-manager - DISABLED (use existing cert-manager with letsencrypt-prod ClusterIssuer)
+installCertmanager: false
+
 certmanager-issuer:
   email: ops@last-try.org
 


### PR DESCRIPTION
## Summary
- Disable GitLab's bundled cert-manager using `installCertmanager: false`
- Remove `cert-manager.io/cluster-issuer` annotation from ingress config
- Add `kas.ops.last-try.org` to the explicit Certificate CRD
- We already have cert-manager installed with letsencrypt-prod ClusterIssuer

## Problem
The ingress annotation was triggering cert-manager's ingress-shim to auto-create Certificate resources. This was overwriting our explicit Certificate CRD, resulting in certificates that only covered one hostname (kas.ops.last-try.org) instead of all three.

## Changes
- Remove `cert-manager.io/cluster-issuer` annotation from global ingress config
- Set `installCertmanager: false` at root level
- Add `kas.ops.last-try.org` to our Certificate dnsNames
- Keep `certmanager-issuer.email` for certificate configuration

## Test plan
- [ ] ArgoCD shows gitlab application as Synced
- [ ] No cert-manager CRD conflicts
- [ ] TLS certificate covers all hostnames (gitlab, registry, kas)
- [ ] `curl https://gitlab.ops.last-try.org` works with valid cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)