### PR TITLE
fix(gitlab): add ignoreDifferences for Valkey StatefulSet K8s defaults

### DIFF
--- a/apps/workloads/gitlab.yaml
+++ b/apps/workloads/gitlab.yaml
@@ -34,6 +34,42 @@ spec:
       path: workloads/gitlab
       directory:
         include: "*-sealed.yaml"
+  # Ignore K8s default fields added by API server/controllers
+  # Prevents OutOfSync for StatefulSet fields like imagePullPolicy, protocol, volumeMode, etc.
+  # Reference: https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: gitlab-valkey
+      namespace: gitlab-system
+      managedFieldsManagers:
+        - kube-controller-manager
+      jqPathExpressions:
+        # VolumeClaimTemplate defaults
+        - .spec.volumeClaimTemplates[]?.spec.volumeMode
+        # Container defaults
+        - .spec.template.spec.containers[]?.imagePullPolicy
+        - .spec.template.spec.containers[]?.terminationMessagePath
+        - .spec.template.spec.containers[]?.terminationMessagePolicy
+        - .spec.template.spec.containers[]?.ports[]?.protocol
+        # Probe defaults
+        - .spec.template.spec.containers[]?.livenessProbe.failureThreshold
+        - .spec.template.spec.containers[]?.livenessProbe.successThreshold
+        - .spec.template.spec.containers[]?.livenessProbe.timeoutSeconds
+        - .spec.template.spec.containers[]?.readinessProbe.failureThreshold
+        - .spec.template.spec.containers[]?.readinessProbe.successThreshold
+        - .spec.template.spec.containers[]?.readinessProbe.timeoutSeconds
+        # Pod spec defaults
+        - .spec.template.spec.dnsPolicy
+        - .spec.template.spec.restartPolicy
+        - .spec.template.spec.schedulerName
+        - .spec.template.spec.securityContext
+        - .spec.template.spec.terminationGracePeriodSeconds
+        # StatefulSet spec defaults
+        - .spec.podManagementPolicy
+        - .spec.revisionHistoryLimit
+        - .spec.updateStrategy
+        - .spec.persistentVolumeClaimRetentionPolicy
   destination:
     server: https://kubernetes.default.svc
     namespace: gitlab-system

--- a/workloads/gitlab/valkey/statefulset.yaml
+++ b/workloads/gitlab/valkey/statefulset.yaml
@@ -8,11 +8,6 @@ metadata:
 spec:
   serviceName: gitlab-valkey
   replicas: 1
-  podManagementPolicy: OrderedReady
-  revisionHistoryLimit: 10
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Retain
-    whenScaled: Retain
   selector:
     matchLabels:
       app: gitlab-valkey
@@ -24,7 +19,6 @@ spec:
       containers:
         - name: valkey
           image: valkey/valkey:9.0.0-alpine
-          imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
@@ -45,7 +39,6 @@ spec:
           ports:
             - containerPort: 6379
               name: redis
-              protocol: TCP
           resources:
             requests:
               cpu: 100m
@@ -61,27 +54,17 @@ spec:
               command: ["valkey-cli", "ping"]
             initialDelaySeconds: 10
             periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 1
           readinessProbe:
             exec:
               command: ["valkey-cli", "ping"]
             initialDelaySeconds: 5
             periodSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
 
         - name: exporter
           image: oliver006/redis_exporter:v1.80.1
-          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9121
               name: metrics
-              protocol: TCP
           env:
             - name: REDIS_ADDR
               value: "redis://localhost:6379"
@@ -92,19 +75,6 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
-
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      partition: 0
 
   volumeClaimTemplates:
     - metadata:
@@ -112,7 +82,6 @@ spec:
       spec:
         accessModes: ["ReadWriteOnce"]
         storageClassName: single-replica  # ADR 0007
-        volumeMode: Filesystem
         resources:
           requests:
             storage: 5Gi


### PR DESCRIPTION
## Summary

- Adds `ignoreDifferences` configuration to gitlab Application for Valkey StatefulSet
- Reverts Valkey StatefulSet manifest to minimal form (removes K8s default bloat)
- Uses ArgoCD's recommended approach for handling Kubernetes-injected default fields

## Problem

Kubernetes API server automatically adds default values to resources:
- `imagePullPolicy: IfNotPresent`
- `protocol: TCP` on ports
- `volumeMode: Filesystem` on PVCs
- Probe defaults: `failureThreshold: 3`, `successThreshold: 1`, `timeoutSeconds: 1`
- Pod defaults: `dnsPolicy: ClusterFirst`, `restartPolicy: Always`, etc.
- StatefulSet defaults: `podManagementPolicy: OrderedReady`, `revisionHistoryLimit: 10`, etc.

These cause ArgoCD to show OutOfSync because live state differs from Git state.

## Solution

Instead of bloating manifests with K8s defaults (which is fragile and verbose), use ArgoCD's `ignoreDifferences` with `jqPathExpressions` to ignore these fields during diff comparison.

Reference: https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/

## Alternatives Considered

| Approach | Pros | Cons |
|----------|------|------|
| **ignoreDifferences (chosen)** | Clean manifests, ArgoCD-native | Configuration overhead |
| Add defaults to manifest | Explicit | Bloated, fragile, still misses some fields |
| Valkey operator | Abstracts StatefulSet | No mature operator exists (per ADR 0005) |

## Impact Analysis

- **Services affected**: gitlab Application (ArgoCD)
- **Breaking changes**: No
- **Database/schema changes**: No
- **API/interface changes**: No
- **Configuration changes**: Yes - ArgoCD Application spec updated
- **Dependencies**: None

## Test Plan

- [ ] ArgoCD shows gitlab Application as Synced after merge
- [ ] Valkey StatefulSet remains healthy (`kubectl get sts gitlab-valkey -n gitlab-system`)
- [ ] No pod restarts triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)