### PR TITLE
feat(gitlab): enable ActionCable for real-time WebSocket features

### DIFF
--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -142,6 +142,10 @@ spec:
           maxReplicas: 2
           workerProcesses: 2
           workerTimeout: 60
+          # ActionCable for real-time WebSocket features (merge requests, issues, etc.)
+          # Required for /-/cable endpoint to work
+          extraEnv:
+            ACTION_CABLE_IN_APP: "true"
           metrics:
             enabled: true
             serviceMonitor:


### PR DESCRIPTION
## Summary

- Enable embedded ActionCable mode by setting `ACTION_CABLE_IN_APP=true` in webservice extraEnv
- Fixes 404 error on `/-/cable` WebSocket endpoint

## Problem

GitLab's real-time features (merge request updates, issue notifications, VS Code GitLab extension) were broken because the `/-/cable` ActionCable endpoint was returning 404 from Rails.

## Solution

Configure ActionCable to run in embedded mode within the Puma webservice by setting the `ACTION_CABLE_IN_APP` environment variable. This enables the WebSocket endpoint without requiring a separate ActionCable container.

## Impact Analysis

- **Services affected**: GitLab webservice deployment
- **Breaking changes**: No
- **Database/schema changes**: No
- **API/interface changes**: No - enables existing endpoint
- **Configuration changes**: Yes - adds extraEnv to webservice

## Test plan

- [ ] Verify webservice pod restarts with new environment variable
- [ ] Check browser console for WebSocket connection to `wss://gitlab.ops.last-try.org/-/cable`
- [ ] Verify no more 404 errors on /-/cable endpoint
- [ ] Test real-time features (open merge request, make changes, see updates)

## References

- [GitLab Issue #2286 - Support Embedded Action Cable in Helm Charts](https://gitlab.com/gitlab-org/charts/gitlab/-/issues/2286)
- [GitLab Webservice Chart Docs](https://docs.gitlab.com/charts/charts/gitlab/webservice/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)