### PR TITLE
fix(argocd): prevent daily sync oscillation for valkey-operator and registry-cache

### DIFF
--- a/apps/infrastructure/registry-cache-dockerhub.yaml
+++ b/apps/infrastructure/registry-cache-dockerhub.yaml
@@ -21,12 +21,21 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: registry-cache
+  # Prevent daily sync oscillation from Helm-generated secret
+  # Reference: https://github.com/argoproj/argo-cd/issues/18530
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: dockerhub-cache-docker-registry-secret
+      jsonPointers:
+        - /data
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+    - RespectIgnoreDifferences=true
     retry:
       limit: 5
       backoff:

--- a/apps/infrastructure/valkey-operator.yaml
+++ b/apps/infrastructure/valkey-operator.yaml
@@ -31,6 +31,19 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: valkey-system
+  # Prevent daily sync oscillation from self-managed webhook TLS rotation
+  # Reference: https://github.com/argoproj/argo-cd/issues/18530
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: valkey-operator-tls
+      jsonPointers:
+        - /data
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: valkey-operator
+      jqPathExpressions:
+        - .webhooks[].clientConfig.caBundle
   syncPolicy:
     automated:
       prune: true
@@ -38,6 +51,7 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      - RespectIgnoreDifferences=true
     retry:
       limit: 3
       backoff:


### PR DESCRIPTION
## Summary

- Add `ignoreDifferences` for auto-generated secrets and webhook configurations
- Add `RespectIgnoreDifferences=true` sync option to both applications

## Problem

Both `valkey-operator` and `registry-cache-dockerhub` were syncing daily (~09:29 and ~14:36) despite no actual changes, causing unnecessary Discord notifications.

**Root causes:**
- **valkey-operator**: Self-managed webhook TLS certificates rotate daily at ~05:30 UTC
- **registry-cache-dockerhub**: Helm chart generates `haSharedSecret` on each render

## Solution

Configure ArgoCD to ignore these auto-generated fields:

### valkey-operator
- Ignore `/data` in `Secret/valkey-operator-tls`
- Ignore `.webhooks[].clientConfig.caBundle` in `ValidatingWebhookConfiguration/valkey-operator`

### registry-cache-dockerhub
- Ignore `/data` in `Secret/dockerhub-cache-docker-registry-secret`

Both apps also get `RespectIgnoreDifferences=true` to ensure ignored fields aren't overwritten during sync.

## Impact Analysis

- **Services affected**: ArgoCD application sync behavior only
- **Breaking changes**: No
- **Database/schema changes**: No
- **Configuration changes**: Yes - ArgoCD Application manifests

## Test plan

- [ ] Verify applications still show as Synced/Healthy
- [ ] Wait 24+ hours and confirm no unnecessary sync notifications
- [ ] Manually trigger sync and verify it completes without issues

## References

- [ArgoCD Issue #18530 - argocd-secret synced every 24 hours](https://github.com/argoproj/argo-cd/issues/18530)
- [Stack Overflow - ArgoCD out-of-sync on auto-generate certs](https://stackoverflow.com/questions/77510338)
- [ArgoCD Sync Options - RespectIgnoreDifferences](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)