### PR TITLE
fix(gitlab): add workhorse cableBackend for ActionCable WebSocket

### DIFF
--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -143,9 +143,12 @@ spec:
           workerProcesses: 2
           workerTimeout: 60
           # ActionCable for real-time WebSocket features (merge requests, issues, etc.)
-          # Required for /-/cable endpoint to work
+          # ACTION_CABLE_IN_APP enables embedded mode in Rails
+          # workhorse.extraArgs tells workhorse to proxy /-/cable to Rails
           extraEnv:
             ACTION_CABLE_IN_APP: "true"
+          workhorse:
+            extraArgs: "-cableBackend http://localhost:8080"
           metrics:
             enabled: true
             serviceMonitor:


### PR DESCRIPTION
## Summary
- Adds `-cableBackend http://localhost:8080` workhorse argument to complete ActionCable WebSocket setup
- Fixes `/-/cable` 404 errors that persisted after enabling ACTION_CABLE_IN_APP=true

## Context
PR #178 added `ACTION_CABLE_IN_APP=true` environment variable to enable embedded ActionCable mode in Rails, but WebSocket connections to `/-/cable` still returned 404 errors.

Investigation revealed that workhorse also needs the `-cableBackend` flag to know where to proxy WebSocket connections. Without this flag, workhorse doesn't route `/-/cable` requests to Rails.

Reference: GitLab CNG docker-compose.yml shows both the env var AND workhorse args are required.

## Impact Analysis
- **Services affected**: gitlab-webservice
- **Breaking changes**: No
- **Configuration changes**: Yes - adds workhorse extraArgs

## Test plan
- [ ] Verify webservice pod restarts with new configuration
- [ ] Check that GITLAB_WORKHORSE_EXTRA_ARGS includes `-cableBackend`
- [ ] Test `/-/cable` endpoint returns 101 Switching Protocols (WebSocket upgrade)
- [ ] Verify real-time features work in GitLab UI (issue updates, MR comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)