### PR TITLE
fix(gitlab): enable ActionCable WebSocket support via Traefik middleware

### DIFF
--- a/workloads/gitlab/operator/forwarded-headers-middleware.yaml
+++ b/workloads/gitlab/operator/forwarded-headers-middleware.yaml
@@ -1,0 +1,13 @@
+# Traefik Middleware to ensure X-Forwarded-Proto: https reaches backend
+# Required for ActionCable origin validation (allow_same_origin_as_host=true)
+# ActionCable compares request Origin (https://...) with rack.url_scheme
+# Without proper X-Forwarded-Proto, Rails sees http scheme, origin check fails → 404
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: forwarded-headers
+  namespace: gitlab-system
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: "https"

--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -26,6 +26,10 @@ spec:
           class: traefik
           # Note: Don't set provider:traefik - causes IngressRouteTCP which operator doesn't support
           configureCertmanager: false
+          # Traefik middleware for ActionCable WebSocket support
+          # Required: X-Forwarded-Proto: https must reach Rails for origin validation
+          annotations:
+            traefik.ingress.kubernetes.io/router.middlewares: gitlab-system-forwarded-headers@kubernetescrd
           tls:
             enabled: true
             secretName: gitlab-tls


### PR DESCRIPTION
## Summary
- Fix GitLab ActionCable WebSocket `/-/cable` endpoint returning 404
- Add Traefik Middleware to set `X-Forwarded-Proto: https` header
- Configure GitLab ingress to use the middleware

## Root Cause
ActionCable's origin validation (`allow_same_origin_as_host=true`) was failing because:
- Origin header: `https://gitlab.ops.last-try.org`
- Rails saw scheme as `http` (X-Forwarded-Proto not reaching Rails)
- Origin mismatch → 404

## Impact
- **Services affected**: GitLab webservice ingress (all GitLab ingresses will get the middleware)
- **Breaking changes**: No
- **Database changes**: No

## Test Plan
- [ ] ArgoCD syncs successfully
- [ ] Middleware created in gitlab-system namespace
- [ ] GitLab ingresses have new annotation
- [ ] WebSocket connection to `/-/cable` returns 101 Switching Protocols
- [ ] Real-time features work in GitLab UI (MR updates, issue comments)

## Evidence
Tested locally - direct requests to Rails with proper `X-Forwarded-Proto: https` header return `101 Switching Protocols`:
```bash
# Through workhorse with proper headers
kubectl exec -n gitlab-system deploy/gitlab-webservice-default -c gitlab-workhorse -- \
  curl -sv --http1.1 -H "Host: gitlab.ops.last-try.org" \
  -H "X-Forwarded-Proto: https" -H "Origin: https://gitlab.ops.last-try.org" \
  -H "Upgrade: websocket" -H "Connection: Upgrade" \
  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  -H "Sec-WebSocket-Version: 13" \
  http://localhost:8181/-/cable
# Returns: HTTP/1.1 101 Switching Protocols
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)