### PR TITLE
feat(gitlab): add GitLab Agent for Kubernetes

### DIFF
--- a/workloads/gitlab-agent/.gitkeep
+++ b/workloads/gitlab-agent/.gitkeep
@@ -1,9 +1,0 @@
-# GitLab Agent Token
-#
-# Create sealed secret with:
-#   kubectl create secret generic gitlab-agent-token \
-#     --namespace=gitlab-agent \
-#     --from-literal=token=YOUR_TOKEN \
-#     --dry-run=client -o yaml | \
-#     kubeseal --cert .sealed-secrets-pub.pem --format yaml > \
-#     workloads/gitlab-agent/gitlab-agent-token-sealed.yaml

--- a/workloads/gitlab-agent/gitlab-agent-token-sealed.yaml
+++ b/workloads/gitlab-agent/gitlab-agent-token-sealed.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: gitlab-agent-token
+  namespace: gitlab-agent
+spec:
+  encryptedData:
+    token: AgCxtlbejU4He3HOTF9D28iKx6rWpN3+8/4cobeh8QM8X8nCVuPJAUCmOOOrlGxINCrT0+gQG6jGewI75NeGSwAp4CbXqHliycWuQ3lLBFLdMYpTmHmMw3yJlpw+N/q4PrQ2ad3g8MI7YY69XS2SPDfSqnSNemojIogNXAK6V9MYMBxbjzHxIF/EjNMPoSFN2Qw7S/p9AO3Nsqo0IwrPbXULGSgTjDXLIAXw7x6Yjw0ZoSczgRUj1VB4SUz36n7Htqf4x2sIhRnWNFIiJZ5t4w6u6nMAnO7LHy5PdLA+LBhTMAV8NLfqHpnK6LPN7EDlkOVCthBt9T+W9J+DVUYHm3F3OX10JJVRxs01LPuzVmaJv+h9NloflLl31ost/tZLvwkGhbnaJpX9ltSroSha2hJCOOwSTmS7w1agZe6tCnBCyhKkOA39JU5u0iIDTn3QYnuLzwOi43e+liHzw4VxXjT4w+BNWbU1SkVYibKa//iXNNpHb7JYiRpXUbkTkxzDVy+279AO/08tBV4LpkwOj/oKGY7mpjT7JBXIOeoTpmTGV6D3bN5I0j3fZLgIIMRJfZWFWu9KLabFuBdQ9C+jzqTqb6gu8X5siEHOegdsaZzbCMy+CeLfkjP6xXqXkV55hYQpS6P8vcf8Yc+YbrBHm/A1TItpzr9aIllmINbQZA5L9U07TFOE7G3TWwsN+Cw1kEeOw0m7kdxka0UKD9R1fnTqZyP0I+vsiocR5QvLpL8Ih89maE4eLrj+QzFdIgRC7XsI9uwWmg==
+  template:
+    metadata:
+      name: gitlab-agent-token
+      namespace: gitlab-agent
+    type: Opaque


### PR DESCRIPTION
## Summary
- Add GitLab Agent for Kubernetes to enable kubectl access from CI/CD pipelines
- Agent connects to KAS via internal cluster service (no external exposure)
- Uses Helm chart from GitLab registry

## Components
- `apps/infrastructure/gitlab-agent.yaml` - ArgoCD Application
- `workloads/gitlab-agent/` - Directory for sealed secret

## Impact
- **Services affected**: New deployment in `gitlab-agent` namespace
- **Breaking changes**: No
- **Dependencies**: Requires agent registration in GitLab + token sealed secret

## Setup Required After Merge
1. Register agent in GitLab: **Operate → Kubernetes clusters → Connect a cluster**
2. Create sealed secret:
   ```bash
   kubectl create secret generic gitlab-agent-token \
     --namespace=gitlab-agent \
     --from-literal=token=<TOKEN> \
     --dry-run=client -o yaml | \
     kubeseal --cert .sealed-secrets-pub.pem --format yaml > \
     workloads/gitlab-agent/gitlab-agent-token-sealed.yaml
   ```
3. Commit sealed secret → ArgoCD deploys agent

## Test Plan
- [ ] Agent pod starts successfully
- [ ] Agent connects to KAS (check logs)
- [ ] kubectl works from GitLab CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)