### PR TITLE
fix(gitlab): correct agent helm chart repository URL

### DIFF
--- a/apps/infrastructure/gitlab-agent.yaml
+++ b/apps/infrastructure/gitlab-agent.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   project: default
   sources:
-    # Helm chart from GitLab registry
-    - repoURL: registry.gitlab.com/gitlab-org/charts/gitlab-agent
+    # Helm chart from GitLab charts repository
+    - repoURL: https://charts.gitlab.io
       chart: gitlab-agent
-      targetRevision: 2.10.0
+      targetRevision: 2.21.1
       helm:
         releaseName: gitlab-agent
         valuesObject:


### PR DESCRIPTION
## Summary
- Fix GitLab Agent helm chart URL from OCI to HTTP format
- Update chart version to 2.21.1 (matches GitLab v18.6.1)

## Impact Analysis
- **Services affected**: gitlab-agent (currently broken)
- **Breaking changes**: No
- **Database changes**: No
- **API changes**: No

## Root Cause
The OCI URL `registry.gitlab.com/gitlab-org/charts/gitlab-agent` was incorrect and version 2.10.0 doesn't exist. The chart is published at `https://charts.gitlab.io`.

## Test plan
- [ ] ArgoCD syncs gitlab-agent application successfully
- [ ] Agent pod starts in gitlab-agent namespace
- [ ] Agent connects to KAS (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)