### PR TITLE
fix(gitlab): increase toolbox memory to prevent OOMKill

### DIFF
--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -261,11 +261,11 @@ spec:
           enabled: true
           resources:
             requests:
-              cpu: 50m
-              memory: 300Mi
+              cpu: 100m
+              memory: 1Gi
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: "1"
+              memory: 2Gi
           backups:
             cron:
               enabled: true


### PR DESCRIPTION
## Summary
- Increase toolbox memory from 512Mi to 2Gi
- Prevents OOMKill when running `gitlab-rails runner`

## Impact Analysis
- **Services affected**: gitlab-toolbox
- **Breaking changes**: No
- **Resource impact**: +1.5Gi memory allocation

## Root Cause
`gitlab-rails runner` loads the full Rails environment which requires ~1-1.5GB memory. The 512Mi limit caused immediate OOMKill (exit code 137).

## Test plan
- [ ] Toolbox pod starts without OOMKill
- [ ] `gitlab-rails runner` commands complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)