### PR TITLE
fix: correct OCI helm chart URLs for Forgejo and Woodpecker

### DIFF
--- a/apps/infrastructure/forgejo.yaml
+++ b/apps/infrastructure/forgejo.yaml
@@ -7,8 +7,7 @@ spec:
   project: default
   sources:
     # 1. Helm chart from Forgejo OCI registry
-    - repoURL: oci://code.forgejo.org/forgejo-helm
-      chart: forgejo
+    - repoURL: oci://code.forgejo.org/forgejo-helm/forgejo
       targetRevision: 15.0.3
       helm:
         releaseName: forgejo

--- a/apps/infrastructure/woodpecker.yaml
+++ b/apps/infrastructure/woodpecker.yaml
@@ -7,9 +7,8 @@ spec:
   project: default
   sources:
     # 1. Helm chart from Woodpecker OCI registry
-    - repoURL: oci://ghcr.io/woodpecker-ci/helm
-      chart: woodpecker
-      targetRevision: 3.0.1
+    - repoURL: oci://ghcr.io/woodpecker-ci/helm/woodpecker
+      targetRevision: 3.4.2
       helm:
         releaseName: woodpecker
         valueFiles:


### PR DESCRIPTION
## Summary

Fix ArgoCD OCI Helm chart syntax for Forgejo and Woodpecker apps.

## Issue

ArgoCD OCI registries require full chart path in `repoURL`, not a separate `chart` field.

**Before (broken):**
```yaml
repoURL: oci://ghcr.io/woodpecker-ci/helm
chart: woodpecker
```

**After (correct):**
```yaml
repoURL: oci://ghcr.io/woodpecker-ci/helm/woodpecker
```

## Changes

- Forgejo: `oci://code.forgejo.org/forgejo-helm/forgejo` (v15.0.3)
- Woodpecker: `oci://ghcr.io/woodpecker-ci/helm/woodpecker` (v3.4.2)

## Test Plan

- [ ] ArgoCD resolves chart revisions
- [ ] Forgejo namespace created and pods running
- [ ] Woodpecker namespace created and pods running

🤖 Generated with [Claude Code](https://claude.com/claude-code)