### PR TITLE
fix: correct ArgoCD OCI syntax - remove oci:// prefix

### DIFF
--- a/apps/infrastructure/forgejo.yaml
+++ b/apps/infrastructure/forgejo.yaml
@@ -6,8 +6,9 @@ metadata:
 spec:
   project: default
   sources:
-    # 1. Helm chart from Forgejo OCI registry
-    - repoURL: oci://code.forgejo.org/forgejo-helm/forgejo
+    # 1. Helm chart from Forgejo OCI registry (no oci:// prefix per ArgoCD docs)
+    - repoURL: code.forgejo.org/forgejo-helm
+      chart: forgejo
       targetRevision: 15.0.3
       helm:
         releaseName: forgejo

--- a/apps/infrastructure/woodpecker.yaml
+++ b/apps/infrastructure/woodpecker.yaml
@@ -6,8 +6,9 @@ metadata:
 spec:
   project: default
   sources:
-    # 1. Helm chart from Woodpecker OCI registry
-    - repoURL: oci://ghcr.io/woodpecker-ci/helm/woodpecker
+    # 1. Helm chart from Woodpecker OCI registry (no oci:// prefix per ArgoCD docs)
+    - repoURL: ghcr.io/woodpecker-ci/helm
+      chart: woodpecker
       targetRevision: 3.4.2
       helm:
         releaseName: woodpecker


### PR DESCRIPTION
## Summary

Fix ArgoCD OCI Helm chart syntax per official docs.

## Issue

ArgoCD docs state: **"the oci:// syntax is not included"** for OCI registries.

**Before (wrong):**
```yaml
repoURL: oci://ghcr.io/woodpecker-ci/helm/woodpecker
```

**After (correct):**
```yaml
repoURL: ghcr.io/woodpecker-ci/helm
chart: woodpecker
```

## Reference

https://argo-cd.readthedocs.io/en/stable/user-guide/helm/

## Test Plan

- [ ] ArgoCD resolves chart revisions successfully
- [ ] Forgejo/Woodpecker apps sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)