### PR TITLE
fix: remove invalid scheduledBackups from PostgreSQL Cluster spec

### DIFF
--- a/infrastructure/forgejo/postgres/cluster.yaml
+++ b/infrastructure/forgejo/postgres/cluster.yaml
@@ -44,7 +44,5 @@ spec:
         compression: gzip
     retentionPolicy: "30d"
 
-  scheduledBackups:
-    - name: forgejo-postgres-backup
-      schedule: "0 0 * * *"
-      backupOwnerReference: self
+# ScheduledBackup is a separate CRD, not inline in Cluster spec
+# TODO: Create ScheduledBackup resource when backup credentials are available

--- a/infrastructure/glitchtip/postgres/cluster.yaml
+++ b/infrastructure/glitchtip/postgres/cluster.yaml
@@ -44,7 +44,5 @@ spec:
         compression: gzip
     retentionPolicy: "30d"
 
-  scheduledBackups:
-    - name: glitchtip-postgres-backup
-      schedule: "0 0 * * *"
-      backupOwnerReference: self
+# ScheduledBackup is a separate CRD, not inline in Cluster spec
+# TODO: Create ScheduledBackup resource when backup credentials are available


### PR DESCRIPTION
## Summary

Fix CloudNativePG Cluster schema validation error.

## Issue

```
.spec.scheduledBackups: field not declared in schema
```

`scheduledBackups` is not a valid inline field in CloudNativePG Cluster spec. Scheduled backups must be created as separate [ScheduledBackup CRDs](https://cloudnative-pg.io/documentation/current/backup_recovery/#scheduled-backups).

## Changes

- Remove invalid `scheduledBackups` from Forgejo and GlitchTip PostgreSQL clusters
- Add TODO comment for future ScheduledBackup resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)