### PR TITLE
fix(glitchtip): use correct worker script name

### DIFF
--- a/infrastructure/glitchtip/app/deployments/worker.yaml
+++ b/infrastructure/glitchtip/app/deployments/worker.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: worker
           image: glitchtip/glitchtip:v5.2.0
-          command: ["bin/run-celery-with-autoreload.sh"]
+          command: ["bin/run-celery.sh"]
           envFrom:
             - configMapRef:
                 name: glitchtip


### PR DESCRIPTION
## Summary

- Fix worker deployment using wrong script name
- `run-celery.sh` instead of `run-celery-with-autoreload.sh`

## Test plan

- [ ] Worker pod starts without CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)