### PR TITLE
fix(forgejo): run oauth-setup job as non-root

### DIFF
--- a/infrastructure/forgejo/oauth-setup-job.yaml
+++ b/infrastructure/forgejo/oauth-setup-job.yaml
@@ -14,6 +14,10 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: oauth-setup
           image: code.forgejo.org/forgejo/forgejo:10


### PR DESCRIPTION
## Summary

- Forgejo refuses to run as root
- Add securityContext with UID 1000 (git user)

## Test plan

- [ ] OAuth setup job completes successfully
- [ ] Dex login button appears on Forgejo login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)