### PR TITLE
fix(glitchtip): use dict for OIDC settings, not JSON string

### DIFF
--- a/infrastructure/glitchtip/app/jobs/oidc-setup.yaml
+++ b/infrastructure/glitchtip/app/jobs/oidc-setup.yaml
@@ -38,7 +38,6 @@ spec:
               echo "Creating Dex OIDC provider..."
               python manage.py shell -c "
               from allauth.socialaccount.models import SocialApp
-              import json
               import os
 
               secret = os.environ.get('OIDC_CLIENT_SECRET', '')
@@ -52,7 +51,7 @@ spec:
                   name='Dex',
                   client_id='glitchtip',
                   secret=secret,
-                  settings=json.dumps({'server_url': 'https://auth.ops.last-try.org'})
+                  settings={'server_url': 'https://auth.ops.last-try.org'}
               )
               print('Created OIDC provider: Dex')
               "


### PR DESCRIPTION
## Summary

Fix OIDC settings format - use dict instead of JSON string.

## Problem

The `/api/settings/` endpoint was returning 500 errors:
```
AttributeError: 'str' object has no attribute 'get'
```

**Root cause**: `SocialApp.settings` is a Django JSONField that expects a dict. Using `json.dumps()` stored a JSON string instead of a dict.

## Solution

Changed from:
```python
settings=json.dumps({'server_url': '...'})  # string
```

To:
```python
settings={'server_url': '...'}  # dict
```

## Impact Analysis

- **Services affected**: GlitchTip
- **Breaking changes**: No (fixes existing bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)