### PR TITLE
fix(glitchtip): correct Valkey service name in REDIS_URL

### DIFF
--- a/infrastructure/glitchtip/app/configmap.yaml
+++ b/infrastructure/glitchtip/app/configmap.yaml
@@ -10,7 +10,7 @@ data:
   CELERY_WORKER_AUTOSCALE: "1,2"
   CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
   EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
-  REDIS_URL: "redis://valkey-glitchtip.glitchtip-system.svc.cluster.local:6379"
+  REDIS_URL: "redis://valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
   # OIDC via Dex
   SOCIALACCOUNT_PROVIDERS__openid_connect__APPS__0__name: "Dex"
   SOCIALACCOUNT_PROVIDERS__openid_connect__APPS__0__provider_id: "dex"


### PR DESCRIPTION
## Summary
- Fix REDIS_URL pointing to non-existent `valkey-glitchtip` service
- SAP Valkey operator creates services with `-primary` suffix

## Impact
- GlitchTip: Dex OIDC login broken (500 error on /redirect)

## Root Cause
SAP Valkey operator creates services named `valkey-{name}-primary` for primary nodes, not `valkey-{name}`. The wrong service name caused connection errors when GlitchTip tried to connect to Redis during the OIDC flow.

## Test Plan
- [ ] Verify GlitchTip pods restart with new config
- [ ] Test Dex login at https://glitchtip.ops.last-try.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)