### PR TITLE
fix(glitchtip): use valkey-glitchtip-binding secret for Redis auth

### DIFF
--- a/infrastructure/glitchtip/app/configmap.yaml
+++ b/infrastructure/glitchtip/app/configmap.yaml
@@ -10,7 +10,6 @@ data:
   CELERY_WORKER_AUTOSCALE: "1,2"
   CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
   EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
-  REDIS_URL: "redis://valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
   # OIDC via Dex
   SOCIALACCOUNT_PROVIDERS__openid_connect__APPS__0__name: "Dex"
   SOCIALACCOUNT_PROVIDERS__openid_connect__APPS__0__provider_id: "dex"

--- a/infrastructure/glitchtip/app/deployments/beat.yaml
+++ b/infrastructure/glitchtip/app/deployments/beat.yaml
@@ -30,6 +30,13 @@ spec:
                 secretKeyRef:
                   name: glitchtip-postgres-app
                   key: uri
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey-glitchtip-binding
+                  key: password
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
           resources:
             requests:
               cpu: 50m

--- a/infrastructure/glitchtip/app/deployments/web.yaml
+++ b/infrastructure/glitchtip/app/deployments/web.yaml
@@ -32,6 +32,13 @@ spec:
                 secretKeyRef:
                   name: glitchtip-postgres-app
                   key: uri
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey-glitchtip-binding
+                  key: password
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
           resources:
             requests:
               cpu: 100m

--- a/infrastructure/glitchtip/app/deployments/worker.yaml
+++ b/infrastructure/glitchtip/app/deployments/worker.yaml
@@ -30,6 +30,13 @@ spec:
                 secretKeyRef:
                   name: glitchtip-postgres-app
                   key: uri
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey-glitchtip-binding
+                  key: password
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
           resources:
             requests:
               cpu: 100m

--- a/infrastructure/glitchtip/app/jobs/migrate.yaml
+++ b/infrastructure/glitchtip/app/jobs/migrate.yaml
@@ -29,6 +29,13 @@ spec:
                 secretKeyRef:
                   name: glitchtip-postgres-app
                   key: uri
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey-glitchtip-binding
+                  key: password
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
           resources:
             requests:
               cpu: 100m

--- a/infrastructure/glitchtip/app/jobs/oidc-setup.yaml
+++ b/infrastructure/glitchtip/app/jobs/oidc-setup.yaml
@@ -68,6 +68,13 @@ spec:
                 secretKeyRef:
                   name: glitchtip-postgres-app
                   key: uri
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey-glitchtip-binding
+                  key: password
+            - name: REDIS_URL
+              value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary.glitchtip-system.svc.cluster.local:6379"
           envFrom:
             - configMapRef:
                 name: glitchtip


### PR DESCRIPTION
## Summary
- Use SAP Valkey operator's binding secret for Redis authentication
- Remove hardcoded REDIS_URL from ConfigMap
- Reference password from `valkey-glitchtip-binding` secret using K8s env var substitution

## Impact
- GlitchTip: All components (web, worker, beat, jobs) now connect to authenticated Valkey

## Root Cause
SAP Valkey operator enables authentication by default. The REDIS_URL without password caused authentication errors and 500 errors on Dex OIDC login.

## Implementation
Uses Kubernetes env var substitution to construct REDIS_URL:
```yaml
env:
  - name: REDIS_PASSWORD
    valueFrom:
      secretKeyRef:
        name: valkey-glitchtip-binding
        key: password
  - name: REDIS_URL
    value: "redis://:$(REDIS_PASSWORD)@valkey-glitchtip-primary..."
```

## Test Plan
- [ ] Pods restart successfully with new config
- [ ] Worker pod runs without CrashLoopBackOff
- [ ] Dex OIDC login works at https://glitchtip.ops.last-try.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)