### PR TITLE
feat(forgejo): expose SSH via LoadBalancer on port 2222

### DIFF
--- a/infrastructure/forgejo/values.yaml
+++ b/infrastructure/forgejo/values.yaml
@@ -32,8 +32,10 @@ service:
     type: ClusterIP
     port: 3000
   ssh:
-    type: ClusterIP
-    port: 22
+    type: LoadBalancer
+    port: 2222
+    annotations:
+      metallb.universe.tf/allow-shared-ip: "default"
 
 # Ingress managed separately
 ingress:
@@ -64,7 +66,7 @@ gitea:
       DOMAIN: git.ops.last-try.org
       ROOT_URL: https://git.ops.last-try.org
       SSH_DOMAIN: git.ops.last-try.org
-      SSH_PORT: 22
+      SSH_PORT: 2222
       DISABLE_SSH: false
       START_SSH_SERVER: true
 


### PR DESCRIPTION
## Summary
- Expose Forgejo SSH externally via MetalLB LoadBalancer
- Use port 2222 to avoid conflict with host SSH
- Update SSH_PORT config for correct clone URL generation

## Changes
- SSH service: ClusterIP → LoadBalancer on port 2222
- SSH_PORT: 22 → 2222 (affects generated clone URLs)
- Added MetalLB IP sharing annotation

## Result
Clone URLs will show: `ssh://git@git.ops.last-try.org:2222/user/repo.git`

## Test Plan
- [ ] SSH service gets external IP from MetalLB
- [ ] Can SSH clone repos: `git clone ssh://git@git.ops.last-try.org:2222/user/repo.git`
- [ ] Forgejo UI shows correct SSH clone URL with port 2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)