### PR TITLE
fix(traefik): add MetalLB IP sharing annotation

### DIFF
--- a/apps/infrastructure/traefik.yaml
+++ b/apps/infrastructure/traefik.yaml
@@ -16,9 +16,11 @@ spec:
           enabled: true
           isDefaultClass: true
 
-        # Service type
+        # Service type - share IP with other LoadBalancer services via MetalLB
         service:
           type: LoadBalancer
+          annotations:
+            metallb.universe.tf/allow-shared-ip: "default"
 
         # Global HTTP to HTTPS redirect
         ports:


### PR DESCRIPTION
## Summary
Add MetalLB IP sharing annotation to Traefik to allow Forgejo SSH to share the same external IP.

## Context
MetalLB requires matching `metallb.universe.tf/allow-shared-ip` annotations on all services that want to share the same IP on different ports.

## Changes
- Traefik service: Added `metallb.universe.tf/allow-shared-ip: "default"`

## Result
- Traefik: 88.99.214.26:80,443
- Forgejo SSH: 88.99.214.26:2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)