### PR TITLE
fix(glitchtip): remove redundant directory.recurse default value

### DIFF
--- a/apps/infrastructure/glitchtip.yaml
+++ b/apps/infrastructure/glitchtip.yaml
@@ -9,8 +9,6 @@ spec:
     repoURL: https://github.com/hitchai-app/gitops
     targetRevision: master
     path: apps/infrastructure/glitchtip
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
## Summary

- Remove `directory.recurse: false` from glitchtip Application spec

## Root Cause

The `directory.recurse: false` is the default value, so Kubernetes drops the entire `directory` block from the live resource. ArgoCD detects this as drift and continuously re-syncs every ~5 minutes, which triggers repeated Discord "infrastructure deployed" notifications.

**Evidence:**
```
# Git manifest has:
directory:
  recurse: false

# Live resource has: (no directory block - default was pruned)
spec:
  source:
    path: apps/infrastructure/glitchtip
    repoURL: https://github.com/hitchai-app/gitops
    targetRevision: master
```

## Impact Analysis

- **Services affected**: glitchtip Application CRD only
- **Breaking changes**: No
- **Behavior change**: No - `recurse: false` is already the default

## Verification

After merge, run:
```bash
kubectl get applications -n argocd infrastructure -o jsonpath='{.status.sync.status}'
# Expected: Synced
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)