### PR TITLE
fix(forgejo-runner): make .runner writable and add labels

### DIFF
--- a/infrastructure/forgejo-runner/config.yaml
+++ b/infrastructure/forgejo-runner/config.yaml
@@ -15,6 +15,9 @@ data:
       insecure: false
       fetch_timeout: 5s
       fetch_interval: 2s
+      labels:
+        - "ubuntu-latest:docker://catthehacker/ubuntu:act-latest"
+        - "docker:docker://catthehacker/ubuntu:act-latest"
     cache:
       enabled: false
     container:

--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -13,8 +13,20 @@ spec:
     template:
       spec:
         restartPolicy: Never
-        # Native sidecar pattern (K8s 1.29+)
         initContainers:
+          # Copy .runner from secret to writable emptyDir
+          - name: copy-runner-config
+            image: busybox:1.36
+            command:
+              - sh
+              - -c
+              - cp /secret/.runner /data/.runner
+            volumeMounts:
+              - name: runner-data
+                mountPath: /data
+              - name: runner-registration
+                mountPath: /secret
+          # Native sidecar pattern (K8s 1.29+)
           - name: dind
             image: docker:27-dind
             restartPolicy: Always
@@ -44,9 +56,6 @@ spec:
             volumeMounts:
               - name: runner-data
                 mountPath: /data
-              - name: runner-registration
-                mountPath: /data/.runner
-                subPath: .runner
               - name: runner-config
                 mountPath: /config
             resources:


### PR DESCRIPTION
## Summary

Fix two issues causing runner pods to fail:

1. **Read-only .runner file** - Secret mounts are read-only, but runner updates this file at runtime
2. **Missing labels** - Runner had no labels, couldn't pick up jobs

## Changes

- Add `copy-runner-config` init container to copy .runner to writable emptyDir
- Add `ubuntu-latest` and `docker` labels to runner config

## Verification

After merge, runner pods should:
1. Start successfully (init container copies .runner)
2. Pick up jobs with matching labels
3. Execute workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)