### PR TITLE
fix(forgejo-runner): wait for Docker daemon before starting

### DIFF
--- a/infrastructure/forgejo-runner/config.yaml
+++ b/infrastructure/forgejo-runner/config.yaml
@@ -26,5 +26,5 @@ data:
       options:
       workdir_parent:
       valid_volumes: []
-      docker_host: tcp://localhost:2375
+      docker_host: unix:///var/run/docker.sock
       force_pull: false

--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -13,6 +13,8 @@ spec:
     template:
       spec:
         restartPolicy: Never
+        # Allow running jobs time to complete on pod termination
+        terminationGracePeriodSeconds: 300
         initContainers:
           # Copy .runner from secret to writable emptyDir
           - name: copy-runner-config
@@ -26,18 +28,30 @@ spec:
                 mountPath: /data
               - name: runner-registration
                 mountPath: /secret
-          # Native sidecar pattern (K8s 1.29+)
+          # Native sidecar pattern (K8s 1.29+) - ARC-style
           - name: dind
             image: docker:27-dind
             restartPolicy: Always
+            args:
+              - dockerd
+              - --host=unix:///var/run/docker.sock
+              - --group=0
             securityContext:
               privileged: true
-            env:
-              - name: DOCKER_TLS_CERTDIR
-                value: ""
+            # Startup probe ensures Docker is ready before runner starts
+            startupProbe:
+              exec:
+                command:
+                  - docker
+                  - info
+              initialDelaySeconds: 0
+              failureThreshold: 24
+              periodSeconds: 5
             volumeMounts:
               - name: docker-graph
                 mountPath: /var/lib/docker
+              - name: dind-sock
+                mountPath: /var/run
             resources:
               requests:
                 cpu: 100m
@@ -53,11 +67,16 @@ spec:
               - one-job
               - --config
               - /config/config.yaml
+            env:
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
             volumeMounts:
               - name: runner-data
                 mountPath: /data
               - name: runner-config
                 mountPath: /config
+              - name: dind-sock
+                mountPath: /var/run
             resources:
               requests:
                 cpu: 100m
@@ -69,6 +88,8 @@ spec:
           - name: docker-graph
             emptyDir: {}
           - name: runner-data
+            emptyDir: {}
+          - name: dind-sock
             emptyDir: {}
           - name: runner-registration
             secret:


### PR DESCRIPTION
## Summary

Adopt ARC (GitHub Actions Runner Controller) pattern for Docker readiness.

## Key Changes (based on ARC implementation)

1. **Startup probe on dind** - Runner won't start until `docker info` succeeds
   ```yaml
   startupProbe:
     exec:
       command: ["docker", "info"]
     failureThreshold: 24  # Up to 2 min wait
     periodSeconds: 5
   ```

2. **Unix socket via shared volume** - More reliable than TCP
   - Shared `dind-sock` volume at `/var/run`
   - `DOCKER_HOST=unix:///var/run/docker.sock`

3. **No wait loop needed** - Kubernetes handles readiness via probe

## Why This Works

From [Ken Muse's ARC analysis](https://www.kenmuse.com/blog/using-kubernetes-native-sidecars-with-github-arc/):
> "Using a native sidecar guarantees that dind has started before runner... The startup probe guarantees dockerd is functional before workflows execute."

## Verification

After merge, pods should:
1. Init: copy-runner-config completes
2. Init: dind starts, startup probe waits for `docker info`
3. Main: runner starts only after probe passes
4. Workflow executes with working Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)