### PR TITLE
fix(forgejo-runner): make .runner file writable

### DIFF
--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -22,7 +22,7 @@ spec:
             command:
               - sh
               - -c
-              - cp /secret/.runner /data/.runner
+              - cp /secret/.runner /data/.runner && chmod 666 /data/.runner
             volumeMounts:
               - name: runner-data
                 mountPath: /data


### PR DESCRIPTION
## Summary

Fix permission denied error on `/data/.runner`.

## Problem

Init container runs as root and copies `.runner` file with restricted permissions.
Runner container runs as non-root user and cannot write to the file.

```
Error: failed to save runner config: open /data/.runner: permission denied
```

## Fix

Add `chmod 666` after copying to make file writable by any user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)