### PR TITLE
fix(cache-server): correct image tag v8.1.4 → 8.1.4

### DIFF
--- a/infrastructure/forgejo-runner/cache-server.yaml
+++ b/infrastructure/forgejo-runner/cache-server.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cache-server
-          image: ghcr.io/falcondev-oss/github-actions-cache-server:v8.1.4
+          image: ghcr.io/falcondev-oss/github-actions-cache-server:8.1.4
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary

Fix ImagePullBackOff error - ghcr.io tags don't have 'v' prefix.

**Before:** `ghcr.io/falcondev-oss/github-actions-cache-server:v8.1.4` (not found)
**After:** `ghcr.io/falcondev-oss/github-actions-cache-server:8.1.4` (exists)

## Impact

- **Services affected**: actions-cache-server in forgejo-runner namespace
- **Breaking changes**: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)