### PR TITLE
fix: use NODE_EXTRA_CA_CERTS for Node.js CA trust

### DIFF
--- a/infrastructure/forgejo-runner/cache-server.yaml
+++ b/infrastructure/forgejo-runner/cache-server.yaml
@@ -28,7 +28,7 @@ spec:
               value: "actions-cache"
             - name: AWS_ENDPOINT_URL
               value: "https://infra-hl.minio-infra.svc.cluster.local:9000"
-            - name: AWS_CA_BUNDLE
+            - name: NODE_EXTRA_CA_CERTS
               value: "/etc/ssl/certs/minio-ca.crt"
             - name: AWS_REGION
               value: "us-east-1"


### PR DESCRIPTION
## Summary
- Fix CA certificate trust for Node.js cache server

## Problem
AWS_CA_BUNDLE is for AWS SDK (Go), not Node.js. Node.js uses NODE_EXTRA_CA_CERTS.

Error: `Failed to initialize storage driver: unable to verify the first certificate`

## Impact Analysis
- **Services affected**: forgejo-runner cache-server
- **Breaking changes**: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)