### PR TITLE
fix(forgejo): expand postgres volume and disable broken backup

### DIFF
--- a/infrastructure/forgejo/postgres/cluster.yaml
+++ b/infrastructure/forgejo/postgres/cluster.yaml
@@ -17,7 +17,7 @@ spec:
       owner: forgejo
 
   storage:
-    size: 10Gi
+    size: 20Gi
     storageClass: single-replica
 
   resources:
@@ -27,22 +27,22 @@ spec:
     limits:
       memory: 1Gi
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://cluster-backups/forgejo-postgres
-      endpointURL: https://s3.eu-central-003.backblazeb2.com
-      s3Credentials:
-        accessKeyId:
-          name: cloudnativepg-backup-creds
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cloudnativepg-backup-creds
-          key: SECRET_ACCESS_KEY
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-    retentionPolicy: "30d"
-
-# ScheduledBackup is a separate CRD, not inline in Cluster spec
-# TODO: Create ScheduledBackup resource when backup credentials are available
+  # Backup disabled until credentials are configured
+  # WAL files were filling disk because archiving failed with missing credentials
+  # TODO: Create cloudnativepg-backup-creds secret and re-enable
+  # backup:
+  #   barmanObjectStore:
+  #     destinationPath: s3://cluster-backups/forgejo-postgres
+  #     endpointURL: https://s3.eu-central-003.backblazeb2.com
+  #     s3Credentials:
+  #       accessKeyId:
+  #         name: cloudnativepg-backup-creds
+  #         key: ACCESS_KEY_ID
+  #       secretAccessKey:
+  #         name: cloudnativepg-backup-creds
+  #         key: SECRET_ACCESS_KEY
+  #     wal:
+  #       compression: gzip
+  #     data:
+  #       compression: gzip
+  #   retentionPolicy: "30d"


### PR DESCRIPTION
## Summary
- Expand PostgreSQL storage from 10Gi to 20Gi
- Disable backup configuration (credentials never created)

## Root Cause
The `cloudnativepg-backup-creds` secret was never created, causing:
1. WAL archiving to fail continuously
2. WAL files accumulated locally instead of being archived to S3
3. 10Gi disk filled to 99.5% (9.95Gi actual usage)
4. CloudNativePG refused to start to protect data integrity

## Fix
1. **Expand volume to 20Gi** - immediate breathing room
2. **Disable backup config** - stops WAL accumulation until proper credentials configured

## Impact
- **Services affected**: forgejo-postgres
- **Breaking changes**: No
- **Data loss**: None (existing data preserved)

## Follow-up Required
- Create `cloudnativepg-backup-creds` sealed secret with Backblaze S3 credentials
- Re-enable backup configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)