### PR TITLE
feat(forgejo-runner): increase runner resource limits

### DIFF
--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -82,8 +82,8 @@ spec:
                 cpu: 100m
                 memory: 128Mi
               limits:
-                cpu: 2000m
-                memory: 1Gi
+                cpu: 4000m
+                memory: 4Gi
         volumes:
           - name: docker-graph
             emptyDir: {}


### PR DESCRIPTION
## Summary
- Increase runner CPU limit: 2000m → 4000m
- Increase runner memory limit: 1Gi → 4Gi

Allows heavier build workloads. CPU overprovisioning is safe (compressible resource).

## Impact
- **Affected**: Forgejo Actions runners (ScaledJob)
- **Breaking changes**: No
- **Max resource usage** (5 runners): 20 CPU / 20Gi (was 10 CPU / 5Gi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)