### PR TITLE
feat(forgejo-runner): optimize performance for faster CI jobs

### DIFF
--- a/infrastructure/forgejo-runner/config.yaml
+++ b/infrastructure/forgejo-runner/config.yaml
@@ -21,6 +21,9 @@ data:
     cache:
       enabled: true
       external_server: http://actions-cache-server.forgejo-runner.svc.cluster.local:3000/
+      # Secret for cache proxy HMAC signing (required for external_server)
+      # Using a static value since falcondev cache server doesn't validate it
+      secret: "forgejo-runner-cache-secret-2024"
     container:
       network: ""
       privileged: false

--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -36,6 +36,8 @@ spec:
               - dockerd
               - --host=unix:///var/run/docker.sock
               - --group=0
+              # Use local registry cache for Docker Hub images
+              - --registry-mirror=http://dockerhub-cache-docker-registry.registry-cache.svc.cluster.local:5000
             securityContext:
               privileged: true
             # Startup probe ensures Docker is ready before runner starts
@@ -58,7 +60,7 @@ spec:
                 memory: 256Mi
               limits:
                 cpu: 2000m
-                memory: 2Gi
+                memory: 4Gi
         containers:
           - name: runner
             image: code.forgejo.org/forgejo/runner:6.3.1
@@ -97,7 +99,7 @@ spec:
           - name: runner-config
             configMap:
               name: forgejo-runner-config
-  pollingInterval: 30
+  pollingInterval: 5
   minReplicaCount: 0
   maxReplicaCount: 5
   rollout:


### PR DESCRIPTION
## Summary

- Enable workflow caching by adding `cache.secret` to runner config (fixes "cache will be disabled" warning)
- Add Docker Hub registry mirror to DinD using existing `registry-cache` infrastructure
- Increase DinD memory from 2Gi to 4Gi for larger image builds
- Reduce KEDA polling interval from 30s to 5s for faster job pickup

## Impact Analysis

- **Services affected**: forgejo-runner ScaledJob and ConfigMap
- **Breaking changes**: No
- **Database/schema changes**: No
- **API/interface changes**: No
- **Configuration changes**: Yes - runner cache enabled, DinD resources increased
- **Dependencies**: Requires existing `registry-cache` namespace with dockerhub-cache service

## Expected Improvement

| Metric | Before | After |
|--------|--------|-------|
| Set up job | ~85s | ~30-40s |
| Image pull | Docker Hub (slow) | Cached (local registry) |
| Workflow cache | Disabled | Working |
| Job detection | 30s polling | 5s polling |

## Test plan

- [ ] Verify ArgoCD syncs successfully
- [ ] Run a workflow and check "Set up job" time improvement
- [ ] Verify cache is working (no "cache will be disabled" warning in logs)
- [ ] Verify registry mirror is used (check DinD logs for mirror usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)