### PR TITLE
feat(infra): add kubernetes-replicator for cross-namespace secret sync

### DIFF
--- a/apps/infrastructure/kubernetes-replicator.yaml
+++ b/apps/infrastructure/kubernetes-replicator.yaml
@@ -28,3 +28,9 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/infrastructure/kubernetes-replicator/values.yaml
+++ b/infrastructure/kubernetes-replicator/values.yaml
@@ -1,5 +1,6 @@
 # kubernetes-replicator values
 # Replicates secrets/configmaps across namespaces
+# Used for PR environments to access stage database credentials via pull-based replication
 
 replicateSecrets: true
 replicateConfigMaps: true
@@ -7,10 +8,19 @@ replicateRoles: false
 replicateRoleBindings: false
 replicateServiceAccounts: false
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
 resources:
   limits:
     cpu: 100m
     memory: 128Mi
   requests:
-    cpu: 10m
+    cpu: 50m
     memory: 32Mi


### PR DESCRIPTION
## Summary
- Adds kubernetes-replicator helm chart to enable cross-namespace secret replication
- Required for PR environments to access stage database credentials

## Impact
- New controller in kube-system namespace
- Enables pull-based secret replication via annotations

## Test plan
- [ ] Verify helm chart deploys successfully
- [ ] Test secret replication from green-stage to green-pr-* namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)