### PR TITLE
fix(registry-cache): add filesystem storage driver for blob caching

### DIFF
--- a/infrastructure/registry-cache/dockerhub/values.yaml
+++ b/infrastructure/registry-cache/dockerhub/values.yaml
@@ -64,9 +64,14 @@ garbageCollect:
   schedule: "0 * * * *"
 
 # Registry configuration
-# Enable deletion for garbage collection to work
+# CRITICAL: Must include filesystem driver for blob caching to work
+# Without this, registry only redirects to Docker Hub instead of caching locally
 configData:
   storage:
+    filesystem:
+      rootdirectory: /var/lib/registry
+    cache:
+      blobdescriptor: inmemory
     delete:
       enabled: true
 


### PR DESCRIPTION
## Summary

- Registry was only caching metadata (~564KB) but **redirecting all blob requests to Docker Hub**
- This caused **35s image pulls** despite having a "cache" in place
- The `configData.storage` block was overriding Helm chart's default filesystem config
- Added explicit `filesystem.rootdirectory` to ensure blobs are stored locally

## Root Cause

The values.yaml had:
```yaml
configData:
  storage:
    delete:
      enabled: true
```

This **replaced** the default filesystem storage driver, causing the registry to only cache blob descriptors in memory while redirecting actual blob downloads to Docker Hub.

## Fix

```yaml
configData:
  storage:
    filesystem:
      rootdirectory: /var/lib/registry  # NEW: Required for blob caching
    cache:
      blobdescriptor: inmemory
    delete:
      enabled: true
```

## Impact Analysis

- **Services affected**: registry-cache (dockerhub pull-through cache)
- **Breaking changes**: No - improves existing functionality
- **Configuration changes**: Yes - registry config updated

## Expected Improvement

| Metric | Before | After |
|--------|--------|-------|
| Cached image pull | 35s (redirect to Docker Hub) | 2-5s (local) |
| Registry storage | 564KB (metadata only) | ~2GB+ (actual blobs) |

## Test Plan

- [ ] ArgoCD syncs registry-cache successfully
- [ ] Pull catthehacker/ubuntu:act-latest and verify it's cached
- [ ] Check `du -sh /var/lib/registry/docker/registry/v2/blobs/` shows GB not KB
- [ ] Second pull should be ~2-5s instead of 35s

🤖 Generated with [Claude Code](https://claude.com/claude-code)