### PR TITLE
fix(cert-manager): remove invalid zoneID field causing sync loop

### DIFF
--- a/infrastructure/cert-manager/letsencrypt-issuer.yaml
+++ b/infrastructure/cert-manager/letsencrypt-issuer.yaml
@@ -21,17 +21,13 @@ spec:
       name: letsencrypt-prod-account-key
 
     # DNS-01 challenge via Cloudflare
-    # Zone ID explicitly set to fix cleanup issues where cert-manager
-    # couldn't find the zone during challenge cleanup (Error 7003)
     solvers:
-    - dns01:
-        cloudflare:
-          email: Alushanov92@gmail.com
-          apiTokenSecretRef:
-            name: cloudflare-api-token
-            key: api-token
-          # last-try.org zone ID - required for proper DNS record cleanup
-          zoneID: "5ce8166ef3eb1c19ae12821226f02f52"
+      - dns01:
+          cloudflare:
+            email: Alushanov92@gmail.com
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -48,10 +44,9 @@ spec:
       name: letsencrypt-staging-account-key
 
     solvers:
-    - dns01:
-        cloudflare:
-          email: Alushanov92@gmail.com
-          apiTokenSecretRef:
-            name: cloudflare-api-token
-            key: api-token
-          zoneID: "5ce8166ef3eb1c19ae12821226f02f52"
+      - dns01:
+          cloudflare:
+            email: Alushanov92@gmail.com
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token


### PR DESCRIPTION
## Problem

The `letsencrypt-issuer` ArgoCD application has been resyncing every 5 minutes with 443+ auto-heal attempts.

## Root Cause

The `zoneID` field in the ClusterIssuer manifests was **never a valid CRD field** for the Cloudflare DNS01 solver. The cert-manager CRD schema for cloudflare only accepts:
- `apiKeySecretRef`
- `apiTokenSecretRef`  
- `email`

Kubernetes Server-Side Apply was stripping the unrecognized `zoneID` field, causing ArgoCD to detect drift and trigger a resync repeatedly.

## Background

The `zoneID` was added in commit a80323b to fix DNS cleanup errors (Error 7003). However, that fix was incorrect - cert-manager handles zone discovery internally since v1.17.1 via `getHostedZoneID()` which traverses up from the ACME record to find the linked zone.

References:
- [cert-manager/cert-manager#7540](https://github.com/cert-manager/cert-manager/issues/7540) - Cloudflare API breaking change
- [cert-manager/cert-manager#7541](https://github.com/cert-manager/cert-manager/pull/7541) - Fix discussion

## Impact

- **Affected services**: cert-manager ClusterIssuers (letsencrypt-prod, letsencrypt-staging)
- **Breaking changes**: None
- **Configuration changes**: Removes invalid field

## Verification

After merge, verify:
```bash
kubectl get application letsencrypt-issuer -n argocd -o jsonpath='{.status.sync.status}'
# Expected: Synced (not OutOfSync)

kubectl get application letsencrypt-issuer -n argocd -o jsonpath='{.status.operationState.operation.sync.autoHealAttemptsCount}'
# Should stop incrementing
```