### PR TITLE
fix(forgejo-runner): increase cache server memory to prevent OOM

### DIFF
--- a/infrastructure/forgejo-runner/cache-server.yaml
+++ b/infrastructure/forgejo-runner/cache-server.yaml
@@ -43,10 +43,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 512Mi
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## Problem

The actions cache server was repeatedly crashing with OOMKilled (exit code 137), causing:
- 14 restarts observed
- Cache wipes on each restart ('Version changed from [no version, first install]... Pruning cache')
- 'Cache not found' errors in CI jobs despite caching being configured

## Root Cause

Memory limit of 256Mi was insufficient for the falcondev cache server when handling S3 storage operations.

## Fix

Increased memory allocation:
- Request: 64Mi → 128Mi
- Limit: 256Mi → 512Mi

## Impact

- **Affected services**: forgejo-runner cache server
- **Breaking changes**: None
- **Resource changes**: +256Mi memory limit for cache server pod

## Verification

After merge:
```bash
# Check no more OOM restarts
kubectl get pods -n forgejo-runner -l app=actions-cache-server -w

# Verify cache is being used (run a CI job twice)
kubectl logs -n forgejo-runner deployment/actions-cache-server --tail=20
```