### PR TITLE
feat(forgejo-runner): add persistent cache for cloned actions

### DIFF
--- a/infrastructure/forgejo-runner/action-cache-pvc.yaml
+++ b/infrastructure/forgejo-runner/action-cache-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: act-action-cache
+  namespace: forgejo-runner
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: single-replica
+  resources:
+    requests:
+      storage: 5Gi

--- a/infrastructure/forgejo-runner/config.yaml
+++ b/infrastructure/forgejo-runner/config.yaml
@@ -27,8 +27,10 @@ data:
     container:
       network: ""
       privileged: false
-      options:
+      # Mount cached actions into job containers
+      options: "-v /act-cache:/root/.cache/act"
       workdir_parent:
-      valid_volumes: []
+      valid_volumes:
+        - /act-cache/**
       docker_host: unix:///var/run/docker.sock
       force_pull: false

--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -54,6 +54,8 @@ spec:
                 mountPath: /var/lib/docker
               - name: dind-sock
                 mountPath: /var/run
+              - name: act-action-cache
+                mountPath: /act-cache
             resources:
               requests:
                 cpu: 100m
@@ -93,6 +95,9 @@ spec:
             emptyDir: {}
           - name: dind-sock
             emptyDir: {}
+          - name: act-action-cache
+            persistentVolumeClaim:
+              claimName: act-action-cache
           - name: runner-registration
             secret:
               secretName: forgejo-runner-registration


### PR DESCRIPTION
## Problem

The 'Set up job' step takes ~1m35s because actions are cloned from external sources on every job run:
- `https://data.forgejo.org/actions/checkout`
- `https://github.com/dtolnay/rust-toolchain`
- `https://data.forgejo.org/actions/cache`

## Solution

Add a persistent volume to cache cloned action repositories between job runs. The `nektos/act` engine (used by Forgejo runner) stores cloned actions at `~/.cache/act`.

## Changes

1. **New PVC** (`action-cache-pvc.yaml`):
   - 5Gi RWO volume using `single-replica` storage class
   - Sufficient for common actions

2. **ScaledJob updates**:
   - Mount PVC to DinD container at `/act-cache`
   - Volume available to job containers via Docker

3. **Runner config updates**:
   - `container.options`: Mount `/act-cache` to `/root/.cache/act` in job containers
   - `valid_volumes`: Allow `/act-cache/**` mounts

## Architecture

```
┌─────────────────────────────────────────────┐
│  Runner Pod                                 │
│  ┌──────────────┐    ┌──────────────────┐  │
│  │   DinD       │    │   Runner         │  │
│  │ /act-cache ◄─┼────┼── PVC mounted    │  │
│  └──────┬───────┘    └──────────────────┘  │
│         │                                   │
│         ▼                                   │
│  ┌──────────────────────────────────────┐  │
│  │  Job Container (catthehacker/ubuntu) │  │
│  │  /root/.cache/act ◄── -v /act-cache  │  │
│  └──────────────────────────────────────┘  │
└─────────────────────────────────────────────┘
```

## Impact

- **Affected services**: forgejo-runner jobs
- **Breaking changes**: None
- **Storage**: +5Gi PVC
- **Expected improvement**: 'Set up job' reduced from ~1m35s to ~10-20s (after first run)

## Trade-offs

- **RWO limitation**: PVC binds to single node (fine for current single-node setup)
- **Future multi-node**: Can switch to RWX if needed

## Verification

After merge, run two CI jobs and compare 'Set up job' times:
```bash
# First job: clones actions (still slow)
# Second job: uses cache (should be fast)

# Check cache contents
kubectl exec -n forgejo-runner <dind-pod> -- ls -la /act-cache
```