### PR TITLE
fix(forgejo-runner): mount action cache to runner container, not DinD

### DIFF
--- a/infrastructure/forgejo-runner/config.yaml
+++ b/infrastructure/forgejo-runner/config.yaml
@@ -27,10 +27,8 @@ data:
     container:
       network: ""
       privileged: false
-      # Mount cached actions into job containers
-      options: "-v /act-cache:/root/.cache/act"
+      options:
       workdir_parent:
-      valid_volumes:
-        - /act-cache/**
+      valid_volumes: []
       docker_host: unix:///var/run/docker.sock
       force_pull: false

--- a/infrastructure/forgejo-runner/scaledjob.yaml
+++ b/infrastructure/forgejo-runner/scaledjob.yaml
@@ -54,8 +54,6 @@ spec:
                 mountPath: /var/lib/docker
               - name: dind-sock
                 mountPath: /var/run
-              - name: act-action-cache
-                mountPath: /act-cache
             resources:
               requests:
                 cpu: 100m
@@ -81,6 +79,8 @@ spec:
                 mountPath: /config
               - name: dind-sock
                 mountPath: /var/run
+              - name: act-action-cache
+                mountPath: /data/.cache/act
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Problem

PR #237 mounted the action cache PVC to the DinD container at `/act-cache` and tried to pass it to job containers via `container.options`. This didn't work because:

1. Actions are cached by the **runner** at `/data/.cache/act`, not by job containers
2. The `container.options` volume mount wasn't being applied to job containers

Verified by checking a running job:
```bash
# Actions cached in runner container:
kubectl exec -c runner -- ls /data/.cache/act
# actions-cache@v4  actions-checkout@v4

# But PVC at /act-cache in DinD was empty
```

## Solution

Mount the PVC directly to the runner container at `/data/.cache/act` where forgejo-runner actually caches cloned actions.

## Changes

- `scaledjob.yaml`: Move PVC mount from DinD to runner container
- `config.yaml`: Remove unused `container.options` and `valid_volumes`

## Impact

- **Affected services**: forgejo-runner
- **Breaking changes**: None
- **Expected result**: Actions cached between jobs, faster 'Set up job' step

## Verification

After merge, run two CI jobs:
```bash
# First job: clones actions (slow)
# Second job: uses cached actions (fast)

# Verify cache persists
kubectl exec -n forgejo-runner <runner-pod> -c runner -- ls -la /data/.cache/act
```