### PR TITLE
fix(gitlab): align chart version with operator

### DIFF
--- a/apps/workloads/gitlab-operator.yaml
+++ b/apps/workloads/gitlab-operator.yaml
@@ -11,7 +11,7 @@ spec:
     repoURL: https://charts.gitlab.io
     chart: gitlab-operator
     # Upgrade sequence: operator first, then GitLab CR chart version
-    # Operator 2.6.x supports GitLab chart 9.7.x
+    # Operator 2.6.x supports GitLab chart 9.6.x
     targetRevision: 2.6.2
     helm:
       releaseName: gitlab-operator

--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: gitlab-system
 spec:
   chart:
-    version: "9.7.0"
+    version: "9.6.2"
     values:
       global:
         # Domain configuration


### PR DESCRIPTION
## Summary
- Align GitLab chart version with the operator admission webhook allow-list
- Keep operator at latest available chart (2.6.2)

## Version Selection
- gitlab chart: 9.6.2 (latest supported by operator 2.6.2)
- gitlab-operator chart: 2.6.2 (latest stable)

## Validation
- Not run (recommended):
  - kubectl diff -k workloads/gitlab
  - kubectl apply --dry-run=server -k workloads/gitlab

## Notes
- Admission webhook currently allows 9.6.2 / 9.5.4 / 9.4.6; 9.7.0 is rejected.
