### PR TITLE
fix(gitlab-oidc): align provider name with dex

### DIFF
--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -114,11 +114,12 @@ spec:
           # OmniAuth configuration for Dex SSO
           omniauth:
             enabled: true
-            autoSignInWithProvider: openid_connect
+            # Provider name is derived from args.name (dex) in the OIDC config.
+            autoSignInWithProvider: dex
             allowSingleSignOn:
-              - openid_connect
+              - dex
             syncProfileFromProvider:
-              - openid_connect
+              - dex
             syncProfileAttributes:
               - email
             blockAutoCreatedUsers: false


### PR DESCRIPTION
## Summary
- Align GitLab omniauth provider name with Dex (`args.name: dex`)
- Prevent missing `user_openid_connect_...` route by using `dex` in auto sign-in and SSO lists

## Validation
- Not run (recommended):
  - kubectl diff -k workloads/gitlab
