### PR TITLE
feat(gitlab): add SSH LoadBalancer service

### DIFF
--- a/workloads/gitlab/operator/ssh-loadbalancer.yaml
+++ b/workloads/gitlab/operator/ssh-loadbalancer.yaml
@@ -1,0 +1,19 @@
+# GitLab SSH LoadBalancer Service
+# Exposes gitlab-shell externally for git+ssh access on standard port 22
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitlab-ssh
+  namespace: gitlab-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: default
+spec:
+  type: LoadBalancer
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: 2222
+      protocol: TCP
+  selector:
+    app: gitlab-shell
+    release: gitlab


### PR DESCRIPTION
## Summary
- Add MetalLB LoadBalancer service for GitLab SSH access on standard port 22
- Enables standard git SSH syntax: `git clone git@gitlab.ops.last-try.org:group/project.git`

## Impact
- **Services affected**: GitLab (gitlab-shell)
- **Breaking changes**: No

## Test plan
- [ ] Merge PR and wait for ArgoCD sync
- [ ] Verify service gets external IP: `kubectl get svc gitlab-ssh -n gitlab-system`
- [ ] Test SSH access: `ssh -T git@gitlab.ops.last-try.org`
- [ ] Test git clone via SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)