### PR TITLE
fix(alertmanager): add null receiver for Watchdog alerts

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/values.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/values.yaml
@@ -33,6 +33,7 @@ alertmanager:
         webhook_configs:
           - url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
             send_resolved: true
+      - name: "null"  # Silences Watchdog alerts (heartbeat)
 
 grafana:
   ingress:


### PR DESCRIPTION
## Summary

Add missing `null` receiver for Watchdog alerts.

The kube-prometheus-stack chart adds default routes that reference a `null` receiver for Watchdog heartbeat alerts. Without this receiver defined, Alertmanager fails to start with:

```
undefined receiver "null" used in route
```

## Impact Analysis

| Component | Impact |
|-----------|--------|
| Alertmanager | Will start successfully |

**Breaking changes**: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)