### PR TITLE
fix(alertmanager): use native discord_configs

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/values.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/values.yaml
@@ -30,8 +30,8 @@ alertmanager:
       receiver: discord
     receivers:
       - name: discord
-        webhook_configs:
-          - url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
+        discord_configs:
+          - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
             send_resolved: true
       - name: "null"  # Silences Watchdog alerts (heartbeat)
 


### PR DESCRIPTION
## Summary

- Switched Alertmanager receiver from `webhook_configs` to native `discord_configs`
- Fixed nil pointer dereference crash when sending alerts to Discord

## Root Cause

Alertmanager v0.27.0 was crashing immediately after startup with:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe73160]
```

The generic `webhook_configs` sends Alertmanager's JSON format, but Discord expects a different payload format. When Discord returns an error response, Alertmanager's webhook retrier wasn't handling the response correctly, causing the nil pointer dereference.

## Solution

Use Alertmanager's native `discord_configs` which was added in v0.27.0. This properly formats messages for Discord's API.

## Impact

- Alertmanager has been down since Oct 10, 2025 (74 days)
- No alerts have been delivered during this time
- After this fix, alerts will start flowing to Discord

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] Alertmanager pod starts without crashing
- [ ] Watchdog alert suppressed by null receiver
- [ ] Alert notifications appear in Discord channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)