### PR TITLE
fix(alertmanager): use AlertmanagerConfig CRD for Discord

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/resources/alertmanager-config.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/resources/alertmanager-config.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord-notifications
+  namespace: monitoring
+  labels:
+    alertmanagerConfig: main
+spec:
+  route:
+    receiver: discord
+    groupBy: ['alertname', 'namespace']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 3h
+    routes:
+      - receiver: "null"
+        matchers:
+          - name: alertname
+            value: Watchdog
+            matchType: "="
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            key: url
+            name: alertmanager-discord-webhook
+          sendResolved: true
+    - name: "null"

--- a/infrastructure/observability/kube-prometheus-stack/values.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/values.yaml
@@ -17,23 +17,20 @@ alertmanager:
           resources:
             requests:
               storage: 2Gi
-    secrets:
-      - alertmanager-discord-webhook
+    # Use AlertmanagerConfig CRDs for receiver configuration
+    alertmanagerConfigSelector:
+      matchLabels:
+        alertmanagerConfig: main
+    alertmanagerConfigMatcherStrategy:
+      type: None  # Don't add namespace matchers to routes
   config:
     global:
       resolve_timeout: 5m
+    # Minimal route - AlertmanagerConfig handles the actual routing
     route:
-      group_by: ['alertname', 'namespace']
-      group_wait: 30s
-      group_interval: 5m
-      repeat_interval: 3h
-      receiver: discord
+      receiver: "null"
     receivers:
-      - name: discord
-        discord_configs:
-          - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook/url
-            send_resolved: true
-      - name: "null"  # Silences Watchdog alerts (heartbeat)
+      - name: "null"
 
 grafana:
   ingress:


### PR DESCRIPTION
## Summary

- Use AlertmanagerConfig CRD instead of inline config for Discord notifications
- Enables proper secret reference for Discord webhook URL

## Root Cause

The previous PR (#256) used `discord_configs` with `webhook_url_file`, but prometheus-operator v0.73 doesn't support `webhook_url_file` for discord_configs in the inline secret. The operator logged:

```
failed to initialize from secret: no discord webhook URL provided
```

This caused it to fall back to the cached `webhook_configs` which crashes on Discord's error response.

## Solution

Use AlertmanagerConfig CRD which properly supports secret references:

```yaml
discordConfigs:
  - apiURL:
      key: url
      name: alertmanager-discord-webhook
```

## Impact

- Alertmanager has been down for 74+ days
- This fix enables proper Discord notifications without exposing the webhook URL in plaintext

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] AlertmanagerConfig created in monitoring namespace
- [ ] Alertmanager pod starts without crashing
- [ ] prometheus-operator logs show no discord errors
- [ ] Test alert appears in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)