### PR TITLE
fix(oauth2-proxy): fix CSRF and secrets for alertmanager and prometheus

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/resources/oauth2-proxy-alertmanager/deployment.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/resources/oauth2-proxy-alertmanager/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
           - --cookie-secure=true
           - --cookie-domain=.ops.last-try.org
+          - --cookie-csrf-per-request=true
           - --email-domain=*
           - --oidc-groups-claim=groups
           - --allowed-group=hitchai-app:ops


### PR DESCRIPTION
## Summary
- Fix oauth2-proxy for both Alertmanager and Prometheus

## Alertmanager Fixes
- Add `--cookie-csrf-per-request=true` to prevent CSRF validation failures

## Prometheus Fixes  
- Fix cookie-secret (was 44 bytes, now 32 bytes - must be 16/24/32)
- Sync client-secret with Dex (was mismatched by 1 character)
- Add `--cookie-csrf-per-request=true`

## Root Cause
1. **CSRF failures**: Multiple replicas handling OAuth flow can't share CSRF tokens
2. **500 error on Prometheus**: Invalid cookie-secret length (44 bytes) breaks AES encryption
3. **Client secret mismatch**: oauth2-proxy and Dex had slightly different secrets

## Impact Analysis
- **Services affected**: oauth2-proxy-alertmanager, oauth2-proxy-prometheus
- **Breaking changes**: No
- **Configuration changes**: Secrets updated, new flag added to deployments

## References
- [oauth2-proxy #817 - CSRF failures](https://github.com/oauth2-proxy/oauth2-proxy/issues/817)
- [oauth2-proxy #579 - cookie-secret requirements](https://github.com/oauth2-proxy/oauth2-proxy/issues/579)

## Test plan
- [ ] Clear browser cookies for `ops.last-try.org`
- [ ] Access `https://am.ops.last-try.org` - verify login works
- [ ] Access `https://prometheus.ops.last-try.org` - verify login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)