### PR TITLE
fix(monitoring): disable control plane monitoring

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/values.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/values.yaml
@@ -114,3 +114,17 @@ prometheus:
     serviceMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
+
+# Disable control plane monitoring - components bind to localhost (127.0.0.1)
+# and are unreachable from Prometheus pods. Enabling would require either:
+# 1. Binding components to 0.0.0.0 + firewall rules, or
+# 2. Running a metrics proxy with hostNetwork: true
+# See: https://github.com/prometheus-community/helm-charts/issues/204
+kubeScheduler:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false


### PR DESCRIPTION
## Summary

- Disable ServiceMonitors for kube-scheduler, kube-controller-manager, etcd, and kube-proxy

## Why

Control plane components on kubeadm clusters bind metrics endpoints to `127.0.0.1` by default:

| Component | Bind Address |
|-----------|--------------|
| kube-scheduler | `127.0.0.1:10259` |
| kube-controller-manager | `127.0.0.1:10257` |
| etcd | `127.0.0.1:2381` |
| kube-proxy | `127.0.0.1:10249` |

Prometheus pods cannot reach localhost on the node, causing persistent false-positive alerts:
- `KubeSchedulerDown`
- `KubeControllerManagerDown`
- `etcdInsufficientMembers`
- `etcdMembersDown`
- `KubeProxyDown`
- Multiple `TargetDown` alerts

## Alternatives Considered

1. **Bind to 0.0.0.0 + firewall** - Requires SSH access to modify `/etc/kubernetes/manifests/` and firewall configuration
2. **Metrics proxy DaemonSet** - Over-engineered for single-node cluster
3. **Disable monitoring** (this PR) - Simplest, eliminates false positives

## Impact Analysis

- **Services affected**: kube-prometheus-stack only
- **Breaking changes**: No
- **What changes**: Removes 4 ServiceMonitors that were failing anyway

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] False-positive alerts clear within ~5 minutes
- [ ] Prometheus targets page shows no failing control plane targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)