### PR TITLE
docs(adr): GitLab Runner pull_policy decision

### DIFF
--- a/adr/0031-gitlab-runner-pull-policy.md
+++ b/adr/0031-gitlab-runner-pull-policy.md
@@ -1,0 +1,62 @@
+# 0031. GitLab Runner Image Pull Policy
+
+**Status:** Accepted
+
+**Date:** 2025-12-26
+
+## Context
+
+GitLab CI jobs with Kubernetes executor were timing out after 180s waiting for pods to start. Root cause: Containerd has no registry mirror, default `pull_policy="always"` attempts to pull from Docker Hub on every job (slow/rate-limited).
+
+Images are already cached on node (rust:latest, postgres:18-alpine, alpine:latest).
+
+## Decision
+
+Set GitLab Runner's `pull_policy` to "**if-not-present**" to use cached images.
+
+```toml
+[runners.kubernetes]
+  pull_policy = "if-not-present"
+```
+
+## Alternatives Considered
+
+### 1. Containerd Registry Mirror
+Not chosen: Requires manual node-level configuration (Ubuntu, no NixOS automation). Would be proper fix but adds operational complexity for single-node cluster.
+
+### 2. Docker Executor with DinD
+Not chosen: Heavier resource footprint, privileged mode required, more complex than Kubernetes executor.
+
+### 3. Pre-pull Images with DaemonSet
+Not chosen: Same outcome as `if-not-present` with additional infrastructure.
+
+## Consequences
+
+### Positive
+- ✅ Fixes CI timeout blocker immediately
+- ✅ Faster job startup (uses cache)
+- ✅ No infrastructure changes needed
+
+### Negative (Accepted Trade-offs)
+
+**Multi-tenant image access** - Any pod can access cached images without authentication
+**Reality**: Single-project private runner, no multi-tenant isolation to bypass
+
+**Stale image vulnerabilities** - Cached images may miss security patches
+**Reality**: Images already cached; same security posture. Mitigate by manual re-pull when needed.
+
+**Node variance** - Different nodes may have different cached images
+**Reality**: Single-node cluster (N/A)
+
+## When to Reconsider
+
+- Multi-tenant CI with strong isolation requirements
+- Compliance requires automated image freshness scanning
+- Cluster scales to multiple nodes
+- Automation available for containerd configuration (e.g., NixOS module)
+
+## References
+
+- GitLab Issue: https://gitlab.ops.last-try.org/green/green/-/issues/1
+- PR #267: https://github.com/hitchai-app/gitops/pull/267
+- ADR 0009: Secrets Management (single-tenant context)


### PR DESCRIPTION
## Summary
- Document decision to use `pull_policy="if-not-present"` for GitLab Runner
- ADR 0031: Context, alternatives, security trade-offs, and revisit criteria

## Decision
Set `pull_policy` to "if-not-present" to use cached images instead of pulling from Docker Hub on every job, fixing 180s timeout errors.

## ADR Contents
- **Context**: CI jobs timing out, containerd has no registry mirror
- **Decision**: Use `if-not-present` pull policy
- **Alternatives**: Containerd mirror (manual config), Docker DinD executor, DaemonSet pre-pull
- **Trade-offs**: 
  - Single-project runner → multi-tenant concerns don't apply
  - Images already cached → stale image risk is manageable
  - Single-node cluster → node variance N/A
- **Revisit**: Multi-tenant CI, compliance requirements, multi-node, automation available

Full ADR: `adr/0031-gitlab-runner-pull-policy.md`

## Files Changed
- `adr/0031-gitlab-runner-pull-policy.md` (62 lines)

Related: #267, https://gitlab.ops.last-try.org/green/green/-/issues/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>