### PR TITLE
fix(gitlab-runner): remove redundant DinD entrypoint override

### DIFF
--- a/infrastructure/gitlab-runner/values.yaml
+++ b/infrastructure/gitlab-runner/values.yaml
@@ -72,7 +72,6 @@ runners:
         [[runners.kubernetes.services]]
           name = "docker"
           alias = "docker"
-          entrypoint = ["dockerd-entrypoint.sh"]
           command = ["--tls=false"]
 
         [runners.kubernetes.pod_labels]


### PR DESCRIPTION
## Summary
Removes redundant entrypoint override for GitLab Runner's DinD service container that was causing "executable file not found in $PATH" errors.

## Root Cause
The `docker:dind` image already uses `dockerd-entrypoint.sh` as its default entrypoint. The configuration was overriding this with a **relative path** `"dockerd-entrypoint.sh"`, which caused runc to fail because it searches `$PATH` instead of using the full path (`/usr/local/bin/dockerd-entrypoint.sh`).

## Change
- **Removed**: `entrypoint = ["dockerd-entrypoint.sh"]` (line 75)
- **Kept**: `command = ["--tls=false"]` (needed for internal sidecar communication)

## Why This Works
The Docker:dind image's default entrypoint already handles calling `dockerd-entrypoint.sh` with the correct full path. By removing the redundant override, we let the image use its built-in defaults, matching the working ARC runner configuration.

## Impact Analysis
- **Services affected**: gitlab-runner deployment
- **Breaking changes**: No
- **Database changes**: No
- **API/interface changes**: No

## Test Plan
- [ ] ArgoCD syncs the change
- [ ] Trigger test GitLab CI job (green repo)
- [ ] Verify DinD service container starts successfully
- [ ] Verify postgres service container starts successfully  
- [ ] Verify build container starts successfully
- [ ] Job completes without "executable file not found" errors

## Related
- ADR 0031: Documents previous pull_policy fix for GitLab Runner
- ADR 0014: ARC runner architecture (uses default entrypoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>