### PR TITLE
fix(gitlab-runner): remove DinD command override to fix service containers

### DIFF
--- a/infrastructure/gitlab-runner/values.yaml
+++ b/infrastructure/gitlab-runner/values.yaml
@@ -72,7 +72,6 @@ runners:
         [[runners.kubernetes.services]]
           name = "docker"
           alias = "docker"
-          command = ["--tls=false"]
 
         [runners.kubernetes.pod_labels]
           "app.kubernetes.io/name" = "gitlab-runner-job"


### PR DESCRIPTION
## Summary
Remove `command = ["--tls=false"]` from docker:dind service to fix GitLab service container regression.

## Issue
- backend:test job with postgres:18-alpine service failing
- docker:build job with docker:dind service failing
- DinD command override may trigger GitLab Runner service container bug

## Fix
Let docker:dind use default command (no TLS by default)
Should resolve service container startup issues

## Testing
- [ ] Runner pod starts successfully
- [ ] green backend:test works (postgres service)
- [ ] green docker:build works (DinD)

## Related
- MR green!3: feat(ci): migrate from Forgejo to GitLab CI/CD