### PR TITLE
feat(gitlab): upgrade to v9.7.0 (GitLab 18.7.0)

### DIFF
--- a/workloads/gitlab/operator/gitlab.yaml
+++ b/workloads/gitlab/operator/gitlab.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: gitlab-system
 spec:
   chart:
-    version: "9.6.2"
+    version: "9.7.0"
     values:
       global:
         # Domain configuration


### PR DESCRIPTION
## Summary
Upgrade GitLab from chart version 9.6.2 (GitLab 18.6.2) to 9.7.0 (GitLab 18.7.0).

## ⚠️ PREREQUISITE
**Must merge PR #274 (GitLab Operator 2.7.0) FIRST**

Operator 2.6.2 only supports chart 9.6.x. Operator 2.7.0 adds support for chart 9.7.0.

## What's New in 18.7.0
- Improved GitLab Duo Analytics dashboard
- Secret validity checks
- AI-powered model chat selection
- Enhanced automation, visibility, and control
- [Release Notes](https://about.gitlab.com/releases/2025/12/18/gitlab-18-7-released/)

## Changes
- Chart version: 9.6.2 → 9.7.0
- GitLab version: 18.6.2 → 18.7.0

## Upgrade Sequence
1. ✅ Merge PR #274 (Operator 2.7.0)
2. ⏳ Wait for ArgoCD sync (operator upgrade)
3. ✅ Merge this PR (GitLab 9.7.0)
4. ⏳ ArgoCD syncs GitLab CR
5. ⏳ GitLab Operator handles rolling upgrade

## Rollout
- ArgoCD detects change → syncs automatically
- GitLab Operator handles rolling upgrade
- Estimated downtime: 5-10 minutes

## Test Plan
- [ ] PR #274 merged and operator upgraded to 2.7.0
- [ ] ArgoCD syncs GitLab CR successfully
- [ ] GitLab services healthy (webservice, sidekiq, gitaly)
- [ ] GitLab UI accessible
- [ ] CI/CD pipelines working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>