### PR TITLE
feat(gitlab-operator): upgrade to v2.7.0

### DIFF
--- a/apps/workloads/gitlab-operator.yaml
+++ b/apps/workloads/gitlab-operator.yaml
@@ -11,8 +11,8 @@ spec:
     repoURL: https://charts.gitlab.io
     chart: gitlab-operator
     # Upgrade sequence: operator first, then GitLab CR chart version
-    # Operator 2.6.x supports GitLab chart 9.6.x
-    targetRevision: 2.6.2
+    # Operator 2.7.0 supports GitLab chart 9.7.0
+    targetRevision: 2.7.0
     helm:
       releaseName: gitlab-operator
       valuesObject:


### PR DESCRIPTION
## Summary
Upgrade GitLab Operator from v2.6.2 to v2.7.0 to add support for GitLab chart 9.7.0 (GitLab 18.7.0).

## Compatibility Matrix
- **Operator 2.6.2**: Chart 9.6.x (GitLab 18.6.x)
- **Operator 2.7.0**: Chart 9.7.0 (GitLab 18.7.0) ✅

## Changes
- `targetRevision`: 2.6.2 → 2.7.0

## Rollout
- ArgoCD will sync automatically
- Operator pods restart (no downtime)
- **Prerequisite for PR #273** (GitLab 18.7.0 upgrade)

## Test Plan
- [ ] ArgoCD syncs successfully
- [ ] Operator pods healthy
- [ ] GitLab CR remains in Running phase
- [ ] Proceed with PR #273 after operator upgrade

## References
- [GitLab Operator 2.7.0 Release](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/releases)
- [GitLab 18.7.0 Release](https://about.gitlab.com/releases/2025/12/18/gitlab-18-7-released/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)