### PR TITLE
fix(green): switch ArgoCD apps from Forgejo to GitLab

### DIFF
--- a/apps/workloads/green-prod.yaml
+++ b/apps/workloads/green-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://git.ops.last-try.org/green/green-envs.git
+    repoURL: https://gitlab.ops.last-try.org/green/green-envs.git
     targetRevision: main
     path: prod/argocd
   destination:

--- a/apps/workloads/green-stage.yaml
+++ b/apps/workloads/green-stage.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://git.ops.last-try.org/green/green-envs.git
+    repoURL: https://gitlab.ops.last-try.org/green/green-envs.git
     targetRevision: main
     path: stage/argocd
   destination:


### PR DESCRIPTION
## Summary
- Update green-stage and green-prod Application repoURL from Forgejo to GitLab

## Impact
- green-stage: ArgoCD will sync from GitLab instead of Forgejo
- green-prod: ArgoCD will sync from GitLab instead of Forgejo

🤖 Generated with [Claude Code](https://claude.com/claude-code)