### PR TITLE
fix(argocd): grant ops group admin

### DIFF
--- a/infrastructure/argocd/argocd-rbac-cm.yaml
+++ b/infrastructure/argocd/argocd-rbac-cm.yaml
@@ -10,9 +10,8 @@ data:
   # Default policy: deny all by default
   policy.default: role:readonly
 
-  # OIDC SSO users from hitchai-app org get admin access
+  # OIDC SSO users from hitchai-app ops team get admin access
   policy.oidc.csv: |
-    g, hitchai-app:*, role:admin
     g, hitchai-app:ops, role:admin
 
   # Agent debugging role (Option B: Read + Emergency Fix)


### PR DESCRIPTION
## Summary
- grant ArgoCD admin to GitHub team "hitchai-app:ops"
- remove unsupported OIDC username-claim change (no ArgoCD support)

## Rationale
- ArgoCD user info shows  and username is email, so group-based admin is the correct supported mapping.
- ArgoCD does not support  /  in ; relying on groups is the documented approach.

## Validation
- not run (requires cluster access)