### PR TITLE
fix(gitlab-runner): remove global docker service from runner config

### DIFF
--- a/infrastructure/gitlab-runner/values.yaml
+++ b/infrastructure/gitlab-runner/values.yaml
@@ -67,12 +67,6 @@ runners:
           mount_path = "/certs/client"
           medium = "Memory"
 
-        # DinD service container
-        # Automatically started for jobs that need Docker
-        [[runners.kubernetes.services]]
-          name = "docker"
-          alias = "docker"
-
         [runners.kubernetes.pod_labels]
           "app.kubernetes.io/name" = "gitlab-runner-job"
           "gitlab-runner" = "true"


### PR DESCRIPTION
This PR now includes two fixes:

## 1. Remove global docker service (commit 6d98423)
Remove the `[[runners.kubernetes.services]]` section that was defining a global default `docker:latest` service for ALL jobs.

## 2. Set DOCKER_HOST globally (commit f3246d5)
Configure `DOCKER_HOST=tcp://docker:2376` globally in the runner's environment setting for all jobs using docker:dind services with TLS.

## Problem
The `docker:build` job was failing with:
```
ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock
```

## Root Cause
1. Global `docker:latest` service interfered with job-level `docker:dind` declarations
2. DOCKER_HOST was not automatically set when using TLS with docker:dind

## Solution
1. Remove global service container configuration (aligns with official Helm chart defaults)
2. Set DOCKER_HOST globally via `[runners.kubernetes] environment` instead of per-pipeline

## Impact
- ✅ Fixes docker:build job
- ✅ No per-pipeline configuration needed
- ✅ Works for all jobs using docker:dind
- ✅ Aligns with official GitLab Runner best practices

## References
- [GitLab Runner: Environment variables in Helm charts](https://docs.gitlab.com/runner/install/environment_variables_in_helm_charts.html)
- [GitLab Issue #3716: Autoconfigure DOCKER_HOST](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3716)
- [GitLab Forum: Using dind in kubernetes runner with helm](https://forum.gitlab.com/t/using-dind-in-kubernetes-runner-with-helm/41651)