### PR TITLE
fix(gitlab-runner): set DOCKER_HOST globally for docker:dind services

### DIFF
--- a/infrastructure/gitlab-runner/values.yaml
+++ b/infrastructure/gitlab-runner/values.yaml
@@ -27,6 +27,11 @@ runners:
         image = "alpine:latest"
         privileged = true
 
+        # Set DOCKER_HOST for docker:dind services
+        # Services are accessible via their service name (e.g., tcp://docker:2376 for TLS)
+        # Docs: https://docs.gitlab.com/runner/install/environment_variables_in_helm_charts.html
+        environment = ["DOCKER_HOST=tcp://docker:2376"]
+
         # Poll interval for new jobs
         poll_interval = 3
         poll_timeout = 180


### PR DESCRIPTION
## Problem
After removing the global docker service (PR #285), the \`docker:build\` job still fails with:
\`\`\`
ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock
\`\`\`

## Root Cause
When using \`docker:dind\` services with TLS enabled (\`DOCKER_TLS_CERTDIR="/certs"\`), the Docker client needs to know where to connect. GitLab Runner does **NOT** automatically set \`DOCKER_HOST\` when TLS is enabled.

## Solution
Set \`DOCKER_HOST=tcp://docker:2376\` globally in the runner's \`[runners.kubernetes] environment\` configuration. This:
- Applies to all jobs using \`docker:dind\` services
- No per-pipeline configuration needed
- Uses the service DNS name "docker" to connect to port 2376 (TLS endpoint)

## Why This Approach?
1. **Centralized configuration** - Set once in runner config, not every pipeline
2. **Works for all projects** - Any project using this runner benefits
3. **Follows GitLab best practices** - Using Helm chart environment variables
4. **Aligns with documentation** - [Environment variables in Helm charts](https://docs.gitlab.com/runner/install/environment_variables_in_helm_charts.html)

## Testing
After this PR merges and ArgoCD syncs:
1. Wait for ArgoCD to sync (~1-2 minutes)
2. Trigger a new pipeline in the green project
3. Run the \`docker:build\` job to verify it works
4. Check job pod environment includes \`DOCKER_HOST=tcp://docker:2376\`

## References
- [GitLab Runner: Environment variables in Helm charts](https://docs.gitlab.com/runner/install/environment_variables_in_helm_charts.html)
- [GitLab Issue #3716: Autoconfigure DOCKER_HOST](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3716)
- [GitLab Forum: Using dind in kubernetes runner with helm](https://forum.gitlab.com/t/using-dind-in-kubernetes-runner-with-helm/41651)
- Related: PR #285 (removed global docker service)