### PR TITLE
chore(mopoque): remove ArgoCD Image Updater

### DIFF
--- a/apps/workloads/mopoque-stage.yaml
+++ b/apps/workloads/mopoque-stage.yaml
@@ -3,12 +3,6 @@ kind: Application
 metadata:
   name: mopoque-stage
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: backend=registry.ops.last-try.org/lt/mopoque/mopoque/backend,frontend=registry.ops.last-try.org/lt/mopoque/mopoque/frontend
-    argocd-image-updater.argoproj.io/backend.update-strategy: name
-    argocd-image-updater.argoproj.io/backend.allow-tags: regexp:^[a-f0-9]{8}$
-    argocd-image-updater.argoproj.io/frontend.update-strategy: name
-    argocd-image-updater.argoproj.io/frontend.allow-tags: regexp:^[a-f0-9]{8}$
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
## Summary
- Remove ArgoCD Image Updater annotations from mopoque-stage Application
- CI in the mopoque repo will now commit image tags directly to `kustomization.yaml`, making git the single source of truth for deployed versions

## Impact
- **mopoque-stage** ArgoCD app only — no other workloads affected
- Image Updater will stop watching mopoque images (annotations removed)
- ArgoCD auto-sync continues to work as before, just reads tags from git instead of Image Updater overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)