### PR TITLE
fix(longhorn): enable automatic pod deletion on node failure

### DIFF
--- a/apps/infrastructure/longhorn-operator.yaml
+++ b/apps/infrastructure/longhorn-operator.yaml
@@ -23,6 +23,7 @@ spec:
             replicaAutoBalance: "best-effort"
             storageOverProvisioningPercentage: "200"
             storageMinimalAvailablePercentage: "25"
+            nodeDownPodDeletionPolicy: "delete-both-statefulset-and-deployment-pod"
 
           # Backup to Backblaze B2 (S3-compatible, $0.006/GB)
           # Credentials managed by Crossplane (infrastructure/crossplane-providers/b2-longhorn-backup.yaml)


### PR DESCRIPTION
## Summary

- Set `nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod` in Longhorn defaultSettings
- When a node goes down, Longhorn will automatically force-delete pods using its volumes so they can reschedule on healthy nodes

## Context

During k8s-04 outage (2026-04-13), GitLab Gitaly and MinIO pods were stuck `Terminating` on the unreachable node. The volumes had healthy replicas on k8s-03 but pods couldn't be rescheduled because the default policy (`do-nothing`) requires manual intervention. This caused GitLab to return 500 until pods were manually force-deleted.

## Impact

- **Longhorn settings**: Adds one setting to `defaultSettings`
- **Breaking changes**: No
- **Risk**: Low — only triggers when a node is confirmed down by Kubernetes; volumes must have available replicas on other nodes for reattachment

## References

- [Longhorn Node Down Pod Deletion Policy](https://longhorn.io/docs/1.10.0/references/settings/#node-down-pod-deletion-policy)
- Previous incidents: k8s-04 reboot (2026-02-03), k8s-03 network disruption (2026-03-05)

## Test plan

- [ ] Verify ArgoCD syncs the updated Longhorn settings
- [ ] Confirm setting via `kubectl get settings.longhorn.io node-down-pod-deletion-policy -n longhorn-system -o jsonpath='{.value}'`


🤖 Generated with [Claude Code](https://claude.com/claude-code)