### PR TITLE
fix(longhorn): use integer seconds for backup poll interval

### DIFF
--- a/apps/infrastructure/longhorn-operator.yaml
+++ b/apps/infrastructure/longhorn-operator.yaml
@@ -31,7 +31,7 @@ spec:
           defaultBackupStore:
             backupTarget: "s3://hitchai-longhorn-backups@us-east-005/"
             backupTargetCredentialSecret: "longhorn-backup-b2-credentials"
-            pollInterval: "5m"
+            pollInterval: "300"
 
           # Resource limits for Longhorn components
           longhornManager:


### PR DESCRIPTION
## Summary

- Change `pollInterval` from `"5m"` to `"300"` in Longhorn `defaultBackupStore` config
- Longhorn 1.10 Helm values expect poll interval as integer seconds, not a Go duration string

## Context

After k8s-04 hardware reset (e1000e NIC hang incident), the Longhorn manager pod on k8s-04 failed to start with:

```
level=fatal msg="Error starting manager: strconv.ParseInt: parsing \"5m\": invalid syntax"
```

The `pollInterval: "5m"` was being parsed as an integer, causing the manager to crash. This blocked all 9 volume attachments on k8s-04, preventing Sentry Kafka, symbolicator, and web pods from starting.

Managers on k8s-02/k8s-03 were unaffected because they started before this config existed and cached the old value.

## Impact

- **Longhorn settings**: One value format change (`"5m"` → `"300"`)
- **Breaking changes**: No — functionally identical (300 seconds = 5 minutes)
- **Services affected**: Sentry (Kafka, symbolicator, web blocked by volume attachment)

## References

- [Longhorn 1.10 Settings Reference](https://longhorn.io/docs/1.10.1/references/settings/)
- [SUSE Longhorn Default Settings](https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/customize-default-settings.html)
- [Longhorn Issue #11025 - poll interval format](https://github.com/longhorn/longhorn/issues/11025)

## Test plan

- [ ] Verify ArgoCD syncs updated config
- [ ] Confirm longhorn-manager on k8s-04 starts without parse error
- [ ] Verify stuck volumes transition from `attaching` to `attached`


🤖 Generated with [Claude Code](https://claude.com/claude-code)