### PR TITLE
feat(gitlab): add MinIO backup lifecycle rule for automatic cleanup

### DIFF
--- a/workloads/gitlab/minio/backup-lifecycle.yaml
+++ b/workloads/gitlab/minio/backup-lifecycle.yaml
@@ -1,0 +1,41 @@
+# CronJob to ensure MinIO ILM lifecycle rule exists on gitlab-backups bucket.
+# Expires backup objects after 7 days (keeps 1 week of daily backups).
+# GitLab's backup_keep_time only manages local files, not object storage.
+# MinIO Operator Tenant CRD does not support bucket lifecycle policies.
+# See: https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1628
+# See: https://github.com/minio/operator/issues/1010
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gitlab-minio-backup-lifecycle
+  namespace: gitlab-system
+spec:
+  schedule: "30 3 * * 0"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mc
+              image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  . /config/config.env
+                  mc alias set gitlab http://minio.gitlab-system.svc:80 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+                  echo '{"Rules":[{"ID":"backup-retention","Status":"Enabled","Prefix":"","Expiration":{"Days":7},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":3}}]}' \
+                    | mc ilm rule import gitlab/gitlab-backups
+                  mc ilm rule ls gitlab/gitlab-backups
+              volumeMounts:
+                - name: minio-config
+                  mountPath: /config
+                  readOnly: true
+          restartPolicy: OnFailure
+          volumes:
+            - name: minio-config
+              secret:
+                secretName: gitlab-minio-env


### PR DESCRIPTION
## Summary

- Add weekly CronJob that applies MinIO ILM expiration rule to `gitlab-backups` bucket
- Backups older than 7 days are automatically deleted by MinIO's lifecycle scanner
- Fixes indefinite backup accumulation (currently 104 backups / 13GB on a 50G volume at 91% capacity)

## Context

GitLab's `backup_keep_time` [only manages local files](https://docs.gitlab.com/administration/backup_restore/backup_gitlab/), not object storage. The Helm chart has no built-in retention for object storage backups ([gitlab-org/charts/gitlab#1628](https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1628)). The MinIO Operator Tenant CRD also doesn't support bucket lifecycle policies ([minio/operator#1010](https://github.com/minio/operator/issues/1010)).

The CronJob uses `mc ilm rule import` which replaces (not appends) the lifecycle config, making it idempotent on repeated runs.

## Impact

- **Services affected**: GitLab MinIO tenant (`gitlab-system` namespace)
- **Breaking changes**: No — only affects future backup retention
- **Existing backups**: Objects older than 7 days will be cleaned up after the ILM rule is applied and MinIO's scanner processes them

## Test plan

- [ ] ArgoCD syncs CronJob to cluster
- [ ] Manually trigger the job: `kubectl create job --from=cronjob/gitlab-minio-backup-lifecycle test-lifecycle -n gitlab-system`
- [ ] Verify ILM rule applied: exec into MinIO pod and run `mc ilm rule ls` or check job logs
- [ ] Confirm old backups are cleaned up within 24h (MinIO scanner interval)
- [ ] Verify `KubePersistentVolumeFillingUp` alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)