### PR TITLE
fix(sentry): wire cert-manager renewal for sentry.ops.last-try.org

### DIFF
--- a/infrastructure/sentry/values.yaml
+++ b/infrastructure/sentry/values.yaml
@@ -7,6 +7,8 @@ ingress:
   enabled: true
   regexPathStyle: traefik
   ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
   hostname: sentry.ops.last-try.org
   tls:
     - secretName: sentry.ops.last-try.org-tls


### PR DESCRIPTION
## Summary

The Sentry ingress in `infrastructure/sentry/values.yaml` was missing the `cert-manager.io/cluster-issuer` annotation that every other ingress in the repo uses. As a result, cert-manager's ingress-shim never created a `Certificate` CRD for `sentry.ops.last-try.org-tls`, and the TLS secret was hand-provisioned 99 days ago.

## How we found it

External Uptime Kuma monitor (newly deployed on the bastion) flagged `sentry.ops.last-try.org` as DOWN with `certificate has expired`. Verified via openssl + `kubectl get certificate -n sentry-system`:

```
notBefore=Jan 15 18:47:55 2026 GMT
notAfter=Apr 15 18:47:54 2026 GMT     ← expired 10 days ago
$ kubectl get certificate -n sentry-system
No resources found in sentry-system namespace.
```

## Fix

Add the standard annotation matching `infrastructure/dex/ingress.yaml` and friends:

```yaml
ingress:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
```

After sync, cert-manager's ingress-shim will:
1. Create a `Certificate` CRD scoped to `sentry-system`
2. Solve the HTTP-01 challenge via the existing Traefik ingress
3. Write the fresh cert into the existing `sentry.ops.last-try.org-tls` secret name (Traefik picks it up live, no pod restart needed)
4. Renew automatically at the 60-day mark

## Verification (post-merge)

```bash
kubectl get certificate -n sentry-system               # expect: sentry.ops.last-try.org-tls   READY=True
kubectl describe certificate -n sentry-system sentry.ops.last-try.org-tls | grep -E "Status:|notAfter"
echo | openssl s_client -connect sentry.ops.last-try.org:443 -servername sentry.ops.last-try.org 2>/dev/null \
  | openssl x509 -noout -dates
```

External Uptime Kuma `up.last-try.org` Sentry monitor should flip back to UP within ~1 minute of the new cert being live.

## Risk

Low. Annotation-only change; if cert-manager fails to issue, the existing (already-expired) secret is untouched and behavior is unchanged. No rollback friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)