### PR TITLE
feat(cnpg): tune sentry and gitlab postgres per ADR 0046

### DIFF
--- a/adr/0046-cnpg-cluster-tuning-baseline.md
+++ b/adr/0046-cnpg-cluster-tuning-baseline.md
@@ -1,0 +1,105 @@
+# 0046. CNPG Tuning by Workload Class
+
+**Status**: Proposed
+
+**Date**: 2026-04-26
+
+## Context
+
+CNPG ships neutral PostgreSQL defaults. Our clusters serve different workload classes — typical
+app DBs, write-heavy stores (sentry monitor check-ins, metrics, queues), mostly-read services.
+
+A recent sentry-system cleanup failure made the gap concrete: factory autovacuum thresholds fired
+8 times in 100 days on a 1.5 M-row hot table, and cleanup catch-up blew past its CronJob deadline.
+The same defaults are in use across all our clusters.
+
+## Decision
+
+Classify each CNPG cluster by workload and tune the small set of parameters that matter for that
+class. Don't set everything; set what moves the needle.
+
+## Quick Guide
+
+### Step 1 — pick the class
+
+| Class | Signal | Examples |
+|---|---|---|
+| **Write-heavy / high churn** | constant inserts + scheduled or rolling deletes | sentry, metrics, audit, queues |
+| **Mixed OLTP** | balanced reads/writes, transactional app | most product DBs |
+| **Read-heavy** | mostly SELECT, infrequent writes | reporting, content, lookup |
+| **Bulk-load** | sporadic large imports | ETL targets, dev/restore |
+
+### Step 2 — set what matters
+
+**Every cluster (cheap, broad payoff):**
+
+- `maintenance_work_mem` ≈ 25 % of memory limit (default 64 MB starves vacuum / index builds)
+- `effective_cache_size` ≈ 75 % of memory limit (planner uses this — default assumes 4 GB)
+- `shared_buffers` ≈ 25 % of memory limit
+
+**Write-heavy / high churn — add:**
+
+- `autovacuum_vacuum_scale_factor: 0.05` (default 0.20 — fire at 5 % dead, not 20 %)
+- `autovacuum_vacuum_insert_scale_factor: 0.05`
+- `autovacuum_vacuum_cost_limit: 1000` (default 200 — un-throttle vacuum I/O)
+- `autovacuum_naptime: 30s`
+
+**Mixed OLTP — add:**
+
+- `work_mem: 16 MB` (default 4 MB — joins / sorts spill to disk early)
+- Autovacuum: same direction, less aggressive (`scale_factor: 0.10`)
+
+**Read-heavy — add:**
+
+- `random_page_cost: 1.1` (default 4.0 assumes spinning disk; we run SSDs)
+- Bump `shared_buffers` if hot set exceeds 25 % of memory
+
+**Bulk-load — add (during load window):**
+
+- Larger `maintenance_work_mem` (≥ 1 GB) — raise memory limit accordingly
+- `work_mem: 64 MB`
+- Disable autovacuum on the target table during load, `VACUUM ANALYZE` after
+
+### Step 3 — per-table overrides for hot spots
+
+If one table dominates churn in an otherwise normal cluster, tune it at the table level instead of
+cluster-wide:
+
+```sql
+ALTER TABLE foo SET (autovacuum_vacuum_scale_factor = 0.02);
+```
+
+Cleaner than over-vacuuming everything.
+
+## Alternatives Considered
+
+- **Keep CNPG defaults.** Proven inadequate for write-heavy workloads (sentry incident).
+- **Per-cluster PGTune output.** Duplicates effort across similar clusters; ignores per-table
+  heterogeneity.
+- **External dynamic tuning (dbtune et al.).** Extra dependency, opaque to GitOps. Premature.
+
+## Consequences
+
+### Positive
+
+- Concrete: classify → set 4–6 parameters → done.
+- Hot tables can be tuned without changing cluster-wide defaults.
+
+### Negative
+
+- Workload class is a judgment call; misclassification of a cluster with one hot table is the main
+  risk — the per-table override step exists to mitigate it.
+- `shared_buffers` changes require a Postgres restart; other parameters reload only.
+
+## When to Reconsider
+
+- Cluster grows past ~50 GB or sustains > 1k TPS
+- Workload class shifts (read-heavy app grows a metrics table)
+- CNPG ships workload-class profiles upstream
+
+## References
+
+- ADR 0004: CloudNativePG for PostgreSQL
+- ADR 0044: CNPG Backup and Recovery Strategy
+- [Tembo: Optimizing Postgres Autovacuum for High-Churn Tables](https://www.tembo.io/blog/optimizing-postgres-auto-vacuum)
+- [PGTune](https://pgtune.leopard.in.ua/)

--- a/infrastructure/sentry/postgres/cluster.yaml
+++ b/infrastructure/sentry/postgres/cluster.yaml
@@ -9,7 +9,15 @@ spec:
   postgresql:
     parameters:
       max_connections: "200"
-      shared_buffers: "128MB"
+      # Tuning per ADR 0046 (write-heavy: monitor check-ins ~16k/day)
+      shared_buffers: "256MB"
+      effective_cache_size: "768MB"
+      maintenance_work_mem: "256MB"
+      work_mem: "16MB"
+      autovacuum_vacuum_scale_factor: "0.05"
+      autovacuum_vacuum_insert_scale_factor: "0.05"
+      autovacuum_vacuum_cost_limit: "1000"
+      autovacuum_naptime: "30s"
 
   bootstrap:
     initdb:

--- a/workloads/gitlab/postgres/cluster.yaml
+++ b/workloads/gitlab/postgres/cluster.yaml
@@ -12,10 +12,15 @@ spec:
 
   postgresql:
     parameters:
+      # Tuning per ADR 0046 (mixed OLTP)
       shared_buffers: "256MB"
-      effective_cache_size: "512MB"
+      effective_cache_size: "768MB"
+      maintenance_work_mem: "256MB"
       work_mem: "16MB"
-      maintenance_work_mem: "64MB"
+      autovacuum_vacuum_scale_factor: "0.10"
+      autovacuum_vacuum_insert_scale_factor: "0.10"
+      autovacuum_vacuum_cost_limit: "1000"
+      autovacuum_naptime: "30s"
       max_connections: "200"
       log_statement: "ddl"
       log_min_duration_statement: "1000"


### PR DESCRIPTION
## Summary
- Add ADR 0046: workload-class tuning baseline for CNPG clusters (quick guide: classify → set 4–6 parameters)
- Apply tuning to `sentry-postgres` (write-heavy) and `gitlab-postgres` (mixed OLTP) — the two CNPG clusters defined in this repo

## Motivation
Between 2026-04-22 and 04-26 the daily `sentry-sentry-cleanup` CronJob hit `DeadlineExceeded` on 5 consecutive runs (5 `KubeJobFailed` warnings). Investigation found CNPG factory defaults are inadequate for write-heavy workloads:

- Autovacuum on `sentry_monitorcheckin` (1.47M rows / 1.4 GB) fired only **8× in 100 days**
- Default `autovacuum_vacuum_scale_factor=0.20` waits for ~300k dead tuples on this table
- Default `maintenance_work_mem=64MB` makes vacuum take multiple passes
- Cleanup deadline + autovacuum lag = the cleanup job can never catch up once the 90-day retention boundary is crossed

The same factory defaults are fleet-wide. Sentry hit it first because of the high-volume monitor-checkin table; other prod clusters share the latent risk.

## Changes

### `sentry-postgres` (write-heavy)
- `shared_buffers` 128 MB → 256 MB (requires Postgres restart, ~30 s blip)
- `effective_cache_size` 768 MB, `maintenance_work_mem` 256 MB, `work_mem` 16 MB
- Aggressive autovacuum: `vacuum_scale_factor=0.05`, `insert_scale_factor=0.05`, `cost_limit=1000`, `naptime=30s`

### `gitlab-postgres` (mixed OLTP)
- `effective_cache_size` 512 MB → 768 MB (reload only)
- `maintenance_work_mem` 64 MB → 256 MB (reload only)
- Moderate autovacuum: `vacuum_scale_factor=0.10`, `insert_scale_factor=0.10`, `cost_limit=1000`, `naptime=30s`

### `adr/0046-cnpg-cluster-tuning-baseline.md`
Decision record framed as a quick guide: pick a workload class (write-heavy / mixed OLTP / read-heavy / bulk-load), set the 4–6 parameters that matter, use per-table overrides for hot spots in otherwise normal clusters.

## Impact analysis
- **`sentry-postgres`**: brief restart on apply (`shared_buffers` is restart-only). Single-instance cluster, ~30 s of write unavailability. Sentry already degraded (cleanup failing); restart is acceptable.
- **`gitlab-postgres`**: all changes are reload-only (no `shared_buffers` change). No downtime.
- **No schema changes, no data migration, no API changes.**
- Other 10 CNPG clusters (green/kona/fire/mopoque/standalock) live in product repos — out of scope for this PR. ADR 0046 applies to them too; follow-up PRs needed in their respective repos.

## Cleanup CronJob deadline (separate)
This PR addresses the database-side root cause. The `activeDeadlineSeconds: 100` on `sentry-sentry-cleanup` and the missing `MonitorCheckIn` retention split are tracked as follow-ups — let the tuned DB run a few cleanups first to measure real cost before changing the deadline.

## Test plan
- [ ] ArgoCD syncs `sentry` Application → CNPG operator detects `shared_buffers` change → restart sentry-postgres primary
- [ ] `kubectl get cluster -n sentry-system sentry-postgres -o jsonpath='{.spec.postgresql.parameters}'` reflects new params
- [ ] `kubectl exec -n sentry-system sentry-postgres-1 -c postgres -- psql -U postgres -c "SHOW shared_buffers; SHOW autovacuum_vacuum_scale_factor; SHOW maintenance_work_mem;"` confirms applied values
- [ ] ArgoCD syncs `gitlab` Application; gitlab-postgres reloads without restart (`SHOW maintenance_work_mem` returns 256MB)
- [ ] Next `sentry-sentry-cleanup` run completes before deadline (or fails for the same reason → indicates we also need to raise the deadline / split the cron)
- [ ] After ~1 day, autovacuum stats on `sentry_monitorcheckin` show fresh `last_autovacuum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)