### PR TITLE
feat(observability): add 24h time window to KubeJobFailed alert

### DIFF
--- a/infrastructure/observability/kube-prometheus-stack/resources/kube-job-alerts.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/resources/kube-job-alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-job-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: kube-jobs
+      rules:
+        # Replacement for upstream KubeJobFailed (disabled in values.yaml).
+        # Upstream fires forever as long as the failed Job CR exists, which makes
+        # alerts sticky on past failures even after the underlying issue is fixed.
+        # We add a 24h time window: if the Job started >24h ago, the alert clears
+        # whether or not the CR was deleted. Failed Job CRs remain visible via kubectl.
+        - alert: KubeJobFailed
+          annotations:
+            summary: Job failed to complete.
+            description: >-
+              Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+              Investigate logs or `kubectl describe job` for details. This alert
+              auto-clears 24h after job start.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+          expr: |
+            kube_job_failed{job="kube-state-metrics", condition="true"} == 1
+              and on(namespace, job_name) (time() - kube_job_status_start_time) < 86400
+          for: 15m
+          labels:
+            severity: warning

--- a/infrastructure/observability/kube-prometheus-stack/resources/kustomization.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/resources/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - alertmanager-config.yaml
   - alertmanager-discord-webhook-sealed.yaml
   - disk-alerts.yaml
+  - kube-job-alerts.yaml
   - longhorn-alerts.yaml
   # grafana-oauth-secret removed - now uses replicated dex-secrets
   - oauth2-proxy-alertmanager/deployment.yaml

--- a/infrastructure/observability/kube-prometheus-stack/values.yaml
+++ b/infrastructure/observability/kube-prometheus-stack/values.yaml
@@ -114,3 +114,9 @@ prometheus:
     serviceMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
+
+# Disable upstream KubeJobFailed; replaced by resources/kube-job-alerts.yaml
+# with a 24h time window so resolved-but-not-deleted failed Jobs age out.
+defaultRules:
+  disabled:
+    KubeJobFailed: true


### PR DESCRIPTION
## Summary
- Disable upstream `KubeJobFailed` alert (kube-prometheus-stack default)
- Replace with a custom `PrometheusRule` that adds a 24h time window so resolved-but-not-deleted failed Jobs stop alerting

## Motivation
Today's incident (PR #393 + #394 trail) made this concrete:

1. Sentry cleanup CronJob hit `DeadlineExceeded` 5 days running → 5 `KubeJobFailed` alerts
2. We tuned the DB and reran the cleanup manually — issue resolved, no more failures
3. The 5 failed Job CRs from earlier still existed (per `failedJobsHistoryLimit: 5`), so the alerts kept firing
4. Only manual `kubectl delete job` cleared them

The upstream rule is `kube_job_failed > 0` with no time decay. The runbook even instructs operators to delete the Job CR to clear the alert. That's an OK answer for one-off Jobs but bad for CronJobs that retain history — alerts get stuck on history rather than current state.

## Change

### `infrastructure/observability/kube-prometheus-stack/values.yaml`
Disable the upstream rule:
```yaml
defaultRules:
  disabled:
    KubeJobFailed: true
```

### `infrastructure/observability/kube-prometheus-stack/resources/kube-job-alerts.yaml` (new)
Custom rule with the same alertname/severity/for, expression now includes a 24h window:
```promql
kube_job_failed{job="kube-state-metrics", condition="true"} == 1
  and on(namespace, job_name) (time() - kube_job_status_start_time) < 86400
```

`kube_job_status_start_time` is the Unix timestamp of the Job's start. After 24h the right side returns false and the alert clears, regardless of whether the Job CR still exists.

## Impact analysis
- **Genuine current failures**: still alert exactly as before (warning, after `for: 15m`, with the same message)
- **Resolved failures (>24h old)**: no longer alert. The Job CR is still visible via `kubectl get job` for forensics
- **Active failures crossing the 24h boundary**: alert clears even if not investigated. Acceptable trade-off — at 24h, ops should have seen it; if they haven't, the alertstorm will reignite on the next failure
- **No effect on other rules** — only `KubeJobFailed` is overridden

## Test plan
- [ ] ArgoCD syncs `kube-prometheus-stack`; `kubectl get prometheusrule -n monitoring kube-job-alerts` exists
- [ ] Upstream rule no longer present: `kubectl get prometheusrule -n monitoring -o yaml | grep -A2 'alert: KubeJobFailed'` shows only our custom one (release label mismatch)
- [ ] Validate expression in Prometheus UI: `https://prometheus.ops.last-try.org/graph?g0.expr=kube_job_failed{job%3D%22kube-state-metrics%22%2Ccondition%3D%22true%22}%20%3D%3D%201%20and%20on(namespace%2Cjob_name)%20(time()%20-%20kube_job_status_start_time)%20%3C%2086400`
- [ ] If a synthetic failed Job exists from the recent incident (after PR #394 lands and a future failure recurs), confirm it auto-clears 24h after start

🤖 Generated with [Claude Code](https://claude.com/claude-code)